### PR TITLE
Create GitHub Action for PDF generation

### DIFF
--- a/.github/workflows/generate-pdfs.yml
+++ b/.github/workflows/generate-pdfs.yml
@@ -1,0 +1,62 @@
+name: Generate OPORD PDFs
+
+on:
+  # Allow manual triggering from the GitHub Actions tab
+  workflow_dispatch:
+    inputs:
+      commit_message:
+        description: 'Custom commit message (optional)'
+        required: false
+        default: 'Regenerate OPORD PDFs'
+
+  # Optionally trigger on push to markdown files
+  push:
+    paths:
+      - '*.md'
+      - '!README.md'
+      - 'opord-template.html'
+    branches:
+      - main
+      - master
+
+jobs:
+  generate-pdfs:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc wkhtmltopdf
+
+      - name: Make conversion script executable
+        run: chmod +x convert-opords-to-pdf.sh
+
+      - name: Generate PDFs
+        run: ./convert-opords-to-pdf.sh
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          git diff --quiet -- '*.pdf' || echo "changes=true" >> $GITHUB_OUTPUT
+
+      - name: Commit and push changes
+        if: steps.check_changes.outputs.changes == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add *.pdf
+          git commit -m "${{ github.event.inputs.commit_message || 'Regenerate OPORD PDFs' }}"
+          git push
+
+      - name: No changes detected
+        if: steps.check_changes.outputs.changes != 'true'
+        run: echo "No PDF changes detected. Skipping commit."


### PR DESCRIPTION
Creates a workflow that:
- Can be triggered manually via workflow_dispatch
- Optionally auto-triggers on push to markdown or template files
- Installs pandoc and wkhtmltopdf
- Runs the existing convert-opords-to-pdf.sh script
- Commits and pushes any PDF changes back to the repo