### PR TITLE
Add squad organization and weapons loadouts to tactical quick reference

### DIFF
--- a/tac-quick-reference.html
+++ b/tac-quick-reference.html
@@ -413,6 +413,40 @@
 </table>
 </div>
 
+<h4>Typical Combat Load (Infantry Rifle Squad)</h4>
+<div class="table-wrapper">
+<table>
+  <tr>
+    <th style="width:30%">Position</th>
+    <th style="width:70%">Typical Ammunition Load</th>
+  </tr>
+  <tr>
+    <td class="row-header">Riflemen / Squad Leader</td>
+    <td><strong>M4:</strong> 210 rounds (7 magazines × 30 rounds)<br>
+        <strong>Grenades:</strong> 2× fragmentation, 1× smoke</td>
+  </tr>
+  <tr>
+    <td class="row-header">Team Leaders / Grenadiers</td>
+    <td><strong>M4:</strong> 210 rounds (7 magazines × 30 rounds)<br>
+        <strong>M320:</strong> 18-36 rounds 40mm (mix of HE, smoke, illumination)<br>
+        <strong>Grenades:</strong> 2× fragmentation, 1× smoke</td>
+  </tr>
+  <tr>
+    <td class="row-header">Automatic Riflemen</td>
+    <td><strong>M249 SAW:</strong> 600 rounds (typically 3× 200-round drums or linked)<br>
+        <strong>Assistant carries:</strong> Additional 200-600 rounds for SAW<br>
+        <strong>Grenades:</strong> 2× fragmentation, 1× smoke</td>
+  </tr>
+  <tr>
+    <td colspan="2" style="background-color:#FFF2CC; font-size:9pt;">
+      <strong>Planning Factor:</strong> ~1,400-1,600 rounds of 5.56mm per rifle squad (not including SAW), plus 40mm grenades.
+      Squads cross-level ammunition based on mission. AT-4s or other anti-armor weapons distributed as needed (typically 1-2 per squad).
+      Resupply planning accounts for 50% expenditure triggering refit.
+    </td>
+  </tr>
+</table>
+</div>
+
 <h3>Weapons Squad (ATP 3-21.8)</h3>
 <p>The weapons squad provides the platoon's medium machine gun and anti-armor capability. It does not maneuver independently like rifle squads but provides supporting fires to enable rifle squad maneuver.</p>
 


### PR DESCRIPTION
Add new Section 1 detailing typical weapon and ammunition loadouts for infantry rifle squads and weapons squads per ATP 3-21.8. This provides TACs with foundational understanding of squad composition and organic capabilities before covering movement formations and tactics.

Infantry Rifle Squad (9 personnel):
- 7× M4 Carbine
- 4× M320 Grenade Launcher
- 2× M249 SAW

Weapons Squad (9 personnel):
- 7× M4 Carbine
- 2× M240B Machine Gun
- 2× Javelin

Includes TAC evaluation note on assessing candidates' understanding of asset capabilities and task organization. Renumbered all subsequent sections (Movement Formations now Section 2, etc.).