### PR TITLE
Strengthen MDCOAs and rewrite ROE on OPORD variants for doctrinal accuracy

### DIFF
--- a/STX/001b-ambush-detailed.md
+++ b/STX/001b-ambush-detailed.md
@@ -141,10 +141,10 @@ Priority of fires to 2nd Squad. Mortar support is available through company on r
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only valid military targets.
-   2. Use minimum force necessary to accomplish the mission.
-   3. Avoid civilian casualties and collateral damage.
-   4. Positively identify targets before firing.
+   1. Initiate engagement in the kill zone only on the squad leader's signal — no premature fire.
+   2. Engage all enemy personnel and vehicles in the kill zone with assigned weapons until cease-fire is signaled.
+   3. Outside the kill zone, engage only on positive identification (PID) of a hostile act or hostile intent; protect noncombatants on shared routes.
+   4. Cease fire on the squad leader's signal; do not pursue past the limit of advance. Secure detainees and EPWs humanely.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm COBRA courier team composition and cargo at each site.

--- a/STX/001c-ambush-detailed.md
+++ b/STX/001c-ambush-detailed.md
@@ -141,10 +141,10 @@ Priority of fires to 2nd Squad. Mortar support is available through company on r
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only valid military targets.
-   2. Use minimum force necessary to accomplish the mission.
-   3. Avoid civilian casualties and collateral damage.
-   4. Positively identify targets before firing.
+   1. Initiate engagement in the kill zone only on the squad leader's signal — no premature fire.
+   2. Engage all enemy personnel and vehicles in the kill zone with assigned weapons until cease-fire is signaled.
+   3. Outside the kill zone, engage only on positive identification (PID) of a hostile act or hostile intent; protect noncombatants on shared routes.
+   4. Cease fire on the squad leader's signal; do not pursue past the limit of advance. Secure detainees and EPWs humanely.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm VIPER team composition and cargo type at each site.

--- a/STX/001d-ambush-detailed.md
+++ b/STX/001d-ambush-detailed.md
@@ -141,10 +141,10 @@ Priority of fires to 2nd Squad. Mortar support is available through company on r
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only valid military targets.
-   2. Use minimum force necessary to accomplish the mission.
-   3. Avoid civilian casualties and collateral damage.
-   4. Positively identify targets before firing.
+   1. Initiate engagement in the kill zone only on the squad leader's signal — no premature fire.
+   2. Engage all enemy personnel and vehicles in the kill zone with assigned weapons until cease-fire is signaled.
+   3. Outside the kill zone, engage only on positive identification (PID) of a hostile act or hostile intent; protect noncombatants on shared routes.
+   4. Cease fire on the squad leader's signal; do not pursue past the limit of advance. Secure detainees and EPWs humanely.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm WRAITH team composition and equipment type at each site.

--- a/STX/002b-movement-to-contact-detailed.md
+++ b/STX/002b-movement-to-contact-detailed.md
@@ -139,10 +139,10 @@ Priority of fires to 1st Squad. Mortar support is available through company on r
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants posing a threat.
-   2. Use graduated response appropriate to the threat.
-   3. Avoid civilian engagement and minimize collateral damage.
-   4. Report civilian casualties immediately.
+   1. Engage on positive identification (PID) of armed combatants committing a hostile act or demonstrating hostile intent.
+   2. Use graduated force — the minimum necessary to achieve the required effect.
+   3. Maintain contact once made; do not break contact without the PL's approval.
+   4. Protect noncombatants in the contact area; report any civilian casualty to higher immediately.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm COBRA personnel and weapons in each zone.

--- a/STX/002c-movement-to-contact-detailed.md
+++ b/STX/002c-movement-to-contact-detailed.md
@@ -139,10 +139,10 @@ Priority of fires to 1st Squad. Mortar support is available through company on r
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants posing a threat.
-   2. Use graduated response appropriate to the threat.
-   3. Avoid civilian engagement and minimize collateral damage.
-   4. Report civilian casualties immediately.
+   1. Engage on positive identification (PID) of armed combatants committing a hostile act or demonstrating hostile intent.
+   2. Use graduated force — the minimum necessary to achieve the required effect.
+   3. Maintain contact once made; do not break contact without the PL's approval.
+   4. Protect noncombatants in the contact area; report any civilian casualty to higher immediately.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm VIPER personnel and weapons in each zone.

--- a/STX/002d-movement-to-contact-detailed.md
+++ b/STX/002d-movement-to-contact-detailed.md
@@ -139,10 +139,10 @@ Priority of fires to 1st Squad. Mortar support is available through company on r
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants posing a threat.
-   2. Use graduated response appropriate to the threat.
-   3. Avoid civilian engagement and minimize collateral damage.
-   4. Report civilian casualties immediately.
+   1. Engage on positive identification (PID) of armed combatants committing a hostile act or demonstrating hostile intent.
+   2. Use graduated force — the minimum necessary to achieve the required effect.
+   3. Maintain contact once made; do not break contact without the PL's approval.
+   4. Protect noncombatants in the contact area; report any civilian casualty to higher immediately.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm WRAITH personnel and weapons in each zone.

--- a/STX/003b-raid-a-bunker-detailed.md
+++ b/STX/003b-raid-a-bunker-detailed.md
@@ -81,7 +81,7 @@ COBRA has established a distributed communications network across AO STARKE to e
 
 **3. Most Probable Course of Action (MPCOA).** Each COBRA node defends from its current position while operators attempt to transmit a final message and destroy communications equipment and message logs. Nodes do not reinforce each other. If the assault is rapid, operators may not have time to complete destruction before being overrun.
 
-**4. Most Dangerous Course of Action (MDCOA).** COBRA nodes detect friendly movement early and successfully transmit warnings to higher, alerting the entire COBRA network. A COBRA reaction element from an unknown location moves to reinforce one of the nodes. Nodes attempt to relocate communications equipment to a fallback position.
+**4. Most Dangerous Course of Action (MDCOA).** COBRA nodes detect friendly movement during leader's reconnaissance and warn the broader network. A COBRA reaction element of squad strength (8-10 personnel) repositions from outside the AO and counterattacks the most isolated friendly squad during consolidation and SSE, attempting to inflict casualties and recover or destroy communications equipment. Adjacent nodes engage the support element with direct fire from concealed positions in depth to fix it and prevent shift fires onto the counterattack.
 
 ### d. Friendly Forces
 
@@ -141,10 +141,10 @@ Priority of fires to 3rd Squad. Mortar support is available through company on r
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants.
-   2. Use graduated response appropriate to the threat.
-   3. Avoid civilian harm and minimize collateral damage.
-   4. Report civilian casualties immediately.
+   1. Engage all armed personnel resisting on the objective with controlled, accurate fire.
+   2. Positive identification (PID) is required for every engagement; do not engage noncombatants, surrendering personnel, or detainees.
+   3. Use minimum force necessary; transition to controlled fires on the assault-complete / limit of advance signal.
+   4. Secure and humanely handle all detainees, EPWs, and recovered materiel.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm COBRA personnel count and weapons at each node.

--- a/STX/003c-raid-a-bunker-detailed.md
+++ b/STX/003c-raid-a-bunker-detailed.md
@@ -81,7 +81,7 @@ VIPER has established three guarded weapons cache sites across AO BAKER to suppo
 
 **3. Most Probable Course of Action (MPCOA).** Each VIPER guard element defends its cache position with small arms, attempting to hold the site and protect the weapons. Guards fight from their positions and do not attempt to destroy or move the cache. If overrun, remaining VIPER personnel break contact and withdraw. Nodes do not reinforce each other.
 
-**4. Most Dangerous Course of Action (MDCOA).** VIPER guards detect friendly movement and call for a reaction force. A VIPER element from an unknown position moves to reinforce the attacked cache. Guards attempt to move the most valuable cache materials to a fallback position while the assault is in progress.
+**4. Most Dangerous Course of Action (MDCOA).** VIPER guards detect friendly movement and aggressively engage the assault element with massed fire from prepared positions, attempting to break the assault before it closes. A VIPER reaction force of squad strength (8-10 personnel) from outside the AO reinforces the most threatened cache during the assault and envelops the support element from a covered route, attempting to isolate the assault element from its ORP and force decisive engagement on unfavorable terms.
 
 ### d. Friendly Forces
 
@@ -141,10 +141,10 @@ Priority of fires to 3rd Squad. Mortar support is available through company on r
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants.
-   2. Use graduated response appropriate to the threat.
-   3. Avoid civilian harm and minimize collateral damage.
-   4. Report civilian casualties immediately.
+   1. Engage all armed personnel resisting on the objective with controlled, accurate fire.
+   2. Positive identification (PID) is required for every engagement; do not engage noncombatants, surrendering personnel, or detainees.
+   3. Use minimum force necessary; transition to controlled fires on the assault-complete / limit of advance signal.
+   4. Secure and humanely handle all detainees, EPWs, and recovered materiel.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm VIPER guard element composition and weapons at each site.

--- a/STX/003d-raid-a-bunker-detailed.md
+++ b/STX/003d-raid-a-bunker-detailed.md
@@ -81,7 +81,7 @@ WRAITH has deployed intelligence collection nodes across AO CEDAR to systematica
 
 **3. Most Probable Course of Action (MPCOA).** Each WRAITH node defends briefly while analysts attempt to destroy the most sensitive materials — particularly annotated maps, operation plans, and photographic records. Nodes do not reinforce each other. Speed is critical: a rapid assault may overrun the node before full materials destruction.
 
-**4. Most Dangerous Course of Action (MDCOA).** WRAITH nodes detect friendly movement early and successfully destroy all annotated maps and intelligence products before the assault. A WRAITH security element moves to reinforce the most threatened node. One node successfully evacuates its analyst team with key materials.
+**4. Most Dangerous Course of Action (MDCOA).** WRAITH nodes detect friendly movement during leader's reconnaissance and alert each other. A WRAITH reaction element of squad strength (8-10 personnel) from outside the AO counterattacks the assault squad during SSE and consolidation, exploiting the squad's dispersion across the objective and transition out of assault posture. Surviving nodes engage the support element from prepared positions in depth to suppress shift fires and isolate the assault element on the objective.
 
 ### d. Friendly Forces
 
@@ -141,10 +141,10 @@ Priority of fires to 3rd Squad. Mortar support is available through company on r
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants.
-   2. Use graduated response appropriate to the threat.
-   3. Avoid civilian harm and minimize collateral damage.
-   4. Report civilian casualties immediately.
+   1. Engage all armed personnel resisting on the objective with controlled, accurate fire.
+   2. Positive identification (PID) is required for every engagement; do not engage noncombatants, surrendering personnel, or detainees.
+   3. Use minimum force necessary; transition to controlled fires on the assault-complete / limit of advance signal.
+   4. Secure and humanely handle all detainees, EPWs, and recovered materiel.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm WRAITH personnel count and weapons at each node.

--- a/STX/005b-area-zone-reconnaissance-detailed.md
+++ b/STX/005b-area-zone-reconnaissance-detailed.md
@@ -141,10 +141,10 @@ Priority of fires to 1st Squad. Fires are limited to self-defense only. Mortar s
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Avoid engagement unless necessary for self-defense or to break contact.
-   2. Do not compromise the reconnaissance mission unless absolutely necessary.
-   3. Avoid civilian contact and minimize detection.
-   4. Report enemy contact immediately but maintain mission focus on intelligence collection.
+   1. Avoid decisive engagement; engage only in self-defense or to break contact when compromised.
+   2. Stealth, observation, and reporting take priority over engagement at all times.
+   3. Avoid civilian contact; minimize observation of the squad by both OPFOR and civilians.
+   4. Report contact immediately via SALUTE; withdraw to recover and resume the mission whenever feasible.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm or deny COBRA presence at each NAI.

--- a/STX/005c-area-zone-reconnaissance-detailed.md
+++ b/STX/005c-area-zone-reconnaissance-detailed.md
@@ -141,10 +141,10 @@ Priority of fires to 1st Squad. Fires are limited to self-defense only. Mortar s
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Avoid engagement unless necessary for self-defense or to break contact.
-   2. Do not compromise the reconnaissance mission unless absolutely necessary.
-   3. Avoid civilian contact and minimize detection.
-   4. Report enemy contact immediately but maintain mission focus on intelligence collection.
+   1. Avoid decisive engagement; engage only in self-defense or to break contact when compromised.
+   2. Stealth, observation, and reporting take priority over engagement at all times.
+   3. Avoid civilian contact; minimize observation of the squad by both OPFOR and civilians.
+   4. Report contact immediately via SALUTE; withdraw to recover and resume the mission whenever feasible.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm or deny VIPER presence at each NAI.

--- a/STX/005d-area-zone-reconnaissance-detailed.md
+++ b/STX/005d-area-zone-reconnaissance-detailed.md
@@ -141,10 +141,10 @@ Priority of fires to 1st Squad. Fires are limited to self-defense only. Mortar s
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Avoid engagement unless necessary for self-defense or to break contact.
-   2. Do not compromise the reconnaissance mission unless absolutely necessary.
-   3. Avoid civilian contact and minimize detection.
-   4. Report enemy contact immediately but maintain mission focus on intelligence collection.
+   1. Avoid decisive engagement; engage only in self-defense or to break contact when compromised.
+   2. Stealth, observation, and reporting take priority over engagement at all times.
+   3. Avoid civilian contact; minimize observation of the squad by both OPFOR and civilians.
+   4. Report contact immediately via SALUTE; withdraw to recover and resume the mission whenever feasible.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm or deny WRAITH OP presence at each NAI.

--- a/STX/014b-deliberate-attack-detailed.md
+++ b/STX/014b-deliberate-attack-detailed.md
@@ -82,7 +82,7 @@ COBRA has established three small distributed coordination centers across AO STA
 
 **3. Most Probable Course of Action (MPCOA).** Each COBRA center defends while operators attempt to destroy message logs, courier schedules, and encryption materials and transmit a warning. Centers do not reinforce each other. A rapid assault may overrun the center before full materials destruction.
 
-**4. Most Dangerous Course of Action (MDCOA).** COBRA centers detect friendly movement early, successfully transmit warnings to all COBRA cells, and destroy sensitive materials before assault elements arrive. A COBRA reaction element rapidly reinforces one objective.
+**4. Most Dangerous Course of Action (MDCOA).** COBRA centers detect friendly movement during leader's reconnaissance and alert all cells. A COBRA reaction element of squad strength (8-10 personnel) repositions from outside the AO and counterattacks the most isolated friendly squad during consolidation on the objective, attempting to inflict casualties and force a withdrawal before SSE is complete. COBRA may cue improvised indirect fire (mortar or RPG) on consolidating squads from concealed positions in depth.
 
 ### d. Friendly Forces
 
@@ -142,10 +142,10 @@ Priority of fires to 2nd Squad. Mortar support is available through company on r
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants.
-   2. Use minimum force necessary to accomplish the mission.
-   3. Avoid civilian casualties and collateral damage.
-   4. Positively identify targets before firing.
+   1. Engage identified enemy combatants and positions on the objective with positive identification (PID).
+   2. The support element suppresses identified hostile positions; the assault element engages personnel resisting on the objective on PID.
+   3. Use minimum force necessary; protect noncombatants in and near the objective.
+   4. Transition to controlled, defensive fires upon consolidation; secure detainees and EPWs humanely.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm COBRA coordination center locations and security positions.

--- a/STX/014c-deliberate-attack-detailed.md
+++ b/STX/014c-deliberate-attack-detailed.md
@@ -142,10 +142,10 @@ Priority of fires to 2nd Squad. Mortar support is available through company on r
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants.
-   2. Use minimum force necessary to accomplish the mission.
-   3. Avoid civilian casualties and collateral damage.
-   4. Positively identify targets before firing — VIPER leaders may attempt to appear civilian.
+   1. Engage identified enemy combatants and positions on the objective with positive identification (PID) — VIPER leaders may attempt to appear as noncombatants.
+   2. The support element suppresses identified hostile positions; the assault element engages personnel resisting on the objective on PID.
+   3. Use minimum force necessary; protect noncombatants in and near the objective.
+   4. Transition to controlled, defensive fires upon consolidation; secure detainees and EPWs humanely.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm VIPER leadership positions and bodyguard disposition at each objective.

--- a/STX/014d-deliberate-attack-detailed.md
+++ b/STX/014d-deliberate-attack-detailed.md
@@ -82,7 +82,7 @@ WRAITH has established three small planning cells across AO CEDAR, each working 
 
 **3. Most Probable Course of Action (MPCOA).** Security defends while planners immediately attempt to destroy the most sensitive operational documents and withdraw. Cells do not reinforce each other. If assault is rapid, planners may not fully destroy materials before being overrun.
 
-**4. Most Dangerous Course of Action (MDCOA).** WRAITH cells detect friendly movement early, fully destroy all operational plans, and successfully withdraw all planning personnel with remaining materials. A WRAITH security element positions to counterattack the assault element at one objective.
+**4. Most Dangerous Course of Action (MDCOA).** WRAITH cells detect friendly movement during leader's reconnaissance. A WRAITH reaction element of squad strength (8-10 personnel) from outside the AO conducts a coordinated counterattack against the assault element at one objective during consolidation and SSE, exploiting the squad's transition from assault to static posture. WRAITH engages the support element from prepared positions in depth to suppress shift fires, isolating the assault element on the objective and forcing casualties before the squad can break contact.
 
 ### d. Friendly Forces
 
@@ -142,10 +142,10 @@ Priority of fires to 2nd Squad. Mortar support is available through company on r
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants.
-   2. Use minimum force necessary to accomplish the mission.
-   3. Avoid civilian casualties and collateral damage.
-   4. Positively identify targets before firing.
+   1. Engage identified enemy combatants and positions on the objective with positive identification (PID).
+   2. The support element suppresses identified hostile positions; the assault element engages personnel resisting on the objective on PID.
+   3. Use minimum force necessary; protect noncombatants in and near the objective.
+   4. Transition to controlled, defensive fires upon consolidation; secure detainees and EPWs humanely.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm WRAITH planning cell locations and security positions.

--- a/STX/016b-deliberate-attack-detailed.md
+++ b/STX/016b-deliberate-attack-detailed.md
@@ -142,10 +142,10 @@ Priority of fires to 3rd Squad. Mortar support is available through company on r
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants.
-   2. Use minimum force necessary to accomplish the mission.
-   3. Avoid civilian casualties and collateral damage.
-   4. Positively identify targets before firing.
+   1. Engage identified enemy combatants and positions on the objective with positive identification (PID).
+   2. The support element suppresses identified hostile positions; the assault element engages personnel resisting on the objective on PID.
+   3. Use minimum force necessary; protect noncombatants at and near road junctions.
+   4. Transition to controlled, defensive fires upon consolidation; secure detainees and EPWs humanely.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm COBRA checkpoint team positions and strength at each junction.

--- a/STX/016c-deliberate-attack-detailed.md
+++ b/STX/016c-deliberate-attack-detailed.md
@@ -141,10 +141,10 @@ Priority of fires to 3rd Squad. Mortar support is available through company on r
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants.
-   2. Use minimum force necessary to accomplish the mission.
-   3. Avoid civilian casualties and collateral damage.
-   4. Positively identify targets before firing.
+   1. Engage identified enemy combatants and positions on the objective with positive identification (PID).
+   2. The support element suppresses identified hostile positions; the assault element engages personnel resisting on the objective on PID.
+   3. Use minimum force necessary; protect noncombatants at and near road junctions.
+   4. Transition to controlled, defensive fires upon consolidation; secure detainees and EPWs humanely.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm VIPER blocking positions, support weapon locations, and strength at each junction.

--- a/STX/016d-deliberate-attack-detailed.md
+++ b/STX/016d-deliberate-attack-detailed.md
@@ -81,7 +81,7 @@ WRAITH has established a security cordon at three key road junctions across AO S
 
 **3. Most Probable Course of Action (MPCOA).** WRAITH observation posts detect friendly movement, transmit one warning, and withdraw silently north to the main body. The main body returns deliberate, brief fire, then withdraws north into covered terrain before the assault closes. WRAITH accepts no decisive engagement when terrain is the mission — they preserve their force for follow-on screening tasks.
 
-**4. Most Dangerous Course of Action (MDCOA).** WRAITH observation posts detect friendly movement early and pass precise locations to the main body, allowing WRAITH to engage from depth before the friendly squad can establish a support element. WRAITH successfully withdraws all elements before the assault arrives, leaving the objective clear but denying the squad an engagement — and signaling the WRAITH interior.
+**4. Most Dangerous Course of Action (MDCOA).** WRAITH observation posts detect friendly movement during leader's reconnaissance and cue a WRAITH reserve element of squad strength (8-10 personnel) from the interior north of AO STEELE. The reserve counterattacks the most isolated friendly squad during consolidation on the junction while the cordon element fixes the support element from prepared positions in depth to prevent shift fires. WRAITH inflicts casualties, recaptures the junction, and disrupts the platoon's penetration of the cordon before follow-on company forces can exploit.
 
 ### d. Friendly Forces
 
@@ -141,10 +141,10 @@ Priority of fires to 3rd Squad. Mortar support is available through company on r
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants.
-   2. Use minimum force necessary to accomplish the mission.
-   3. Avoid civilian casualties and collateral damage.
-   4. Positively identify targets before firing.
+   1. Engage identified enemy combatants and positions on the objective with positive identification (PID).
+   2. The support element suppresses identified hostile positions; the assault element engages personnel resisting on the objective on PID.
+   3. Use minimum force necessary; protect noncombatants at and near road junctions.
+   4. Transition to controlled, defensive fires upon consolidation; secure detainees and EPWs humanely.
 
 **2. Priority Intelligence Requirements (PIR):**
    1. Confirm WRAITH cordon positions, observation post locations, and strength at each junction.


### PR DESCRIPTION
MDCOA fixes (6 files): 016d previously had WRAITH withdrawing without
engagement — that is friendly-favorable, not dangerous. 003b/c/d, 014b,
and 014d had MDCOAs diluted with mission-failure language (destroying
materials, evacuating personnel) that crowded out the actual threat to
friendly force. Each rewritten MDCOA now describes a specific dangerous
enemy action — squad-strength counterattack from outside the AO or from
the WRAITH interior, executed during the assault squad's consolidation
or SSE when it is most exposed — with surviving enemy elements
suppressing the support element from depth.

ROE rewrites (all 18 variants): replaced four near-identical generic
templates with operation-type ROE that uses doctrinal language (PID,
hostile act/intent, graduated force, LOA cease-fire, controlled fires
on consolidation):
- Ambush: kill-zone initiation, PID outside the kill zone, no pursuit
- Movement to contact: PID, graduated force, maintain contact
- Raid: armed resistance, PID, transition on LOA, detainee handling
- Reconnaissance: avoid decisive engagement, stealth over engagement
- Deliberate attack: PID, support suppresses + assault on PID, transition
  to defensive fires on consolidation