### PR TITLE
Streamline 001-ambush.md: trim duplicated boilerplate from notes and terrain

### DIFF
--- a/STX/001-ambush.md
+++ b/STX/001-ambush.md
@@ -8,31 +8,20 @@
 >
 > **Complexity:** Lower to Moderate | **Recommended Phase:** WALK (Blocks 3-4), RUN (Day Iterations)
 >
-> **Mission Summary:** 1st Platoon conducts three independent squad ambushes in AO COTTO against small REAPER resupply patrols. Each squad operates at its own ambush site.
+> **Training Focus:** Evaluates **individual squad leader planning and decision-making**. The PL issues the platoon OPORD; each SL conducts their own TLP — terrain analysis, ambush layout, assault/support/security assignments, and squad OPORD. Assign one evaluator per squad.
 >
-> **Training Focus:** This OPORD is designed to evaluate **individual squad leader planning and decision-making**. The PL issues the platoon OPORD, but each squad leader must conduct their own TLP — analyzing terrain, selecting an ambush site layout, assigning assault/support/security within the squad, and issuing a squad OPORD. Cadre should assign one evaluator per squad to observe the SL's planning process and tactical decisions.
->
-> **Destinations:**
-> - 1st Squad → OBJ FLUNKER (vic MP 0600 1530)
-> - 2nd Squad → OBJ KLENDATHU (vic MP 0585 1559)
-> - 3rd Squad → OBJ TANGO (vic MP 0575 1538)
->
-> **Actions on Objective:** Each squad independently emplaces a linear ambush at its assigned site, initiates on a small REAPER patrol (3-4 personnel), and withdraws. Squads do not depend on or wait for adjacent squads.
->
-> **Evaluation Timeline:** For evaluated iterations, candidates will receive this OPORD and have 75 minutes to complete TLP Steps 1-8 before SP. Execution window is 60 minutes. AAR is 15 minutes.
+> **Evaluation Timeline:** 75 min for TLP Steps 1-8 before SP. 60 min execution window. 15 min AAR.
 >
 > **OPFOR/Training Wrinkles:**
-> - Deploy one small REAPER patrol (3-4 personnel) per ambush site, operating independently.
-> - Each patrol transits its assigned road segment on cadre signal.
-> - Introduce a civilian or non-combatant at one site to test ROE.
-> - Cadre may inject patrol timing changes, equipment malfunctions, or intel updates per site.
+> - One small REAPER patrol (3-4 personnel) per site, transiting on cadre signal. Patrols operate independently.
+> - Introduce a civilian at one site to test ROE.
+> - Cadre may inject timing changes, equipment malfunctions, or intel updates per site.
 > - If manning is limited, rotate one OPFOR team across sites between iterations.
+> - UAS/Counter-UAS injects are OPTIONAL and only if authorized by the Commandant and in the approved POI.
 >
-> **NOTE:** UAS/Counter-UAS injects are OPTIONAL and should only be used if authorized by the Commandant and incorporated into the approved POI.
+> **Iteration Guidance:** Mission command version — squad tasks state outcomes without prescribing layout or positioning. For scaffolded iterations, use [001-ambush-detailed.md](001-ambush-detailed.md).
 >
 > **See Also:** [LTA Grid Reference](../reference/lta-grid-reference.md)
->
-> **Iteration Guidance:** This is the mission command version — squad tasks state outcomes without prescribing specific ambush layout or positioning. For the first iteration with a new class or candidates who need additional scaffolding, use [001-ambush-detailed.md](001-ambush-detailed.md) instead.
 
 **Time Zone Used Throughout the Plan/Order:** EASTERN STANDARD TIME
 
@@ -50,13 +39,13 @@ Platoon Sergeant
 ## 1. SITUATION
 
 ### a. Area of Interest
-The Camp Blanding LTA, Clay County, Florida. AO COTTO covers the western and central LTA — bounded north by Jacksonville Street, east by Bradenton Avenue, south by Arcadia Street, and west by Clearwater Avenue (vicinity MP 0575 1520 to MP 0610 1565) — where three independent ambush sites are emplaced along Bradenton Avenue, the unnamed N-S road in the western LTA, and Clearwater Avenue. The area of interest extends south of Arcadia Street and east of Bradenton Avenue into the wider Camp Blanding training area, where REAPER assembly areas and resupply nodes outside the LTA feed couriers and patrols into the three road corridors targeted by this operation.
+AO COTTO occupies the western and central Camp Blanding LTA (vic MP 0575 1520 to MP 0610 1565), with ambush sites along Bradenton Ave, the unnamed N-S road in the western LTA, and Clearwater Ave. Area of interest extends south of Arcadia St and east of Bradenton Ave into the wider training area, where REAPER assembly areas feed couriers into the targeted corridors.
 
 ### b. Area of Operations
 
-**1. Terrain.** The Camp Blanding LTA is a road-bounded sector of the training area, roughly 1,200m east-west by 550m north-south, set in flat sandy-soil pine and hardwood forest. An improved road grid frames the LTA: Bradenton Avenue (N-S) runs through the center, Clearwater Avenue (N-S) bounds the west, Arcadia Street (E-W) bounds the south, and Jacksonville Street (E-W) bounds the north. Two unnamed roads — one N-S in the western LTA and one E-W through the interior — subdivide the woodlines. The FOB sits at MP 0610 1550 in the northeast; Conex City sits at MP 0611 1530 in the southeast. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire and the primary mounted avenues of approach. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to the roads, particularly after rain.
+**1. Terrain.** The Camp Blanding LTA is a road-bounded ~1,200m × 550m sector of flat sandy-soil pine and hardwood forest. Improved road grid: Bradenton Ave (N-S, center), Clearwater Ave (N-S, west), Arcadia St (E-W, south), Jacksonville St (E-W, north); two unnamed roads (one N-S in the western LTA, one E-W through the interior) subdivide the woodlines. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to roads. See [LTA Grid Reference](../reference/lta-grid-reference.md) for full terrain notes.
 
-   - **Key Terrain:** Bradenton Avenue is a north-south improved road and the primary REAPER resupply route through the central AO. The unnamed north-south road in the western LTA is a secondary REAPER movement corridor. The intersection of Clearwater Avenue and the unnamed road in the southwestern LTA is a dismounted transit point. Woodlines along each road segment provide concealment for any dismounted element; visibility off the roads is under 50 meters in most areas.
+   - **Key Terrain:** Bradenton Ave (primary REAPER resupply route through the central AO), the unnamed N-S road in the western LTA (secondary REAPER corridor), and the Clearwater Ave / unnamed road intersection in the southwestern LTA (dismounted transit point). Woodlines along each segment provide concealment for dismounted elements.
 
 **2. Weather.**
    - Skies: ________

--- a/STX/002-movement-to-contact.md
+++ b/STX/002-movement-to-contact.md
@@ -8,31 +8,21 @@
 >
 > **Complexity:** Moderate | **Recommended Phase:** WALK (Blocks 3-4), RUN (Day Iterations)
 >
-> **Mission Summary:** 1st Platoon conducts a movement to contact in AO FLUNKER with squads operating independently in assigned zones to locate, engage, and assess REAPER forces. Each squad has its own objective and operates at its own pace.
+> **Training Focus:** Evaluates **individual squad leader planning and decision-making**. The PL issues the platoon OPORD; each SL conducts their own TLP — terrain analysis, movement techniques, formations, actions on contact, and squad OPORD. Assign one evaluator per squad.
 >
-> **Training Focus:** This OPORD is designed to evaluate **individual squad leader planning and decision-making**. The PL issues the platoon OPORD, but each squad leader must conduct their own TLP — analyzing terrain, selecting movement techniques, choosing formations, planning actions on contact, and issuing a squad OPORD. Cadre should assign one evaluator per squad to observe the SL's planning process and tactical decisions.
->
-> **Destinations:**
-> - 1st Squad → OBJ BAINTON (vic MP 0600 1538)
-> - 2nd Squad → OBJ HERRERA (vic MP 0612 1546)
-> - 3rd Squad → OBJ BARLOW (vic MP 0613 1532)
->
-> **Actions on Objective:** Each squad independently locates and engages REAPER in its zone, secures its objective, and reports. Squads do not depend on or wait for adjacent squads.
->
-> **Evaluation Timeline:** For evaluated iterations, candidates will receive this OPORD and have 75 minutes to complete TLP Steps 1-8 before SP. Execution window is 60 minutes. AAR is 15 minutes.
+> **Evaluation Timeline:** 75 min for TLP Steps 1-8 before SP. 60 min execution window. 15 min AAR.
 >
 > **OPFOR/Training Wrinkles:**
-> - Deploy one OPFOR team (2-3 personnel) per zone, positioned near each squad's objective.
-> - Each OPFOR team operates independently — do not coordinate across zones unless running MDCOA.
-> - Introduce a civilian or non-combatant scenario in one zone to test ROE.
-> - Cadre can inject intelligence updates, obstacles, or simulate equipment malfunctions per zone.
-> - Vary OPFOR tactics across zones (one team delays, one ambushes, one defends) to create distinct planning problems for each SL.
+> - One OPFOR team (2-3 personnel) per zone, positioned near each squad's objective.
+> - Teams operate independently — do not coordinate across zones unless running MDCOA.
+> - Introduce a civilian in one zone to test ROE.
+> - Cadre may inject intel updates, obstacles, or equipment malfunctions per zone.
+> - Vary OPFOR tactics across zones (one delays, one ambushes, one defends) to create distinct planning problems for each SL.
+> - UAS/Counter-UAS injects are OPTIONAL and only if authorized by the Commandant and in the approved POI.
 >
-> **NOTE:** UAS/Counter-UAS injects are OPTIONAL and should only be used if authorized by the Commandant and incorporated into the approved POI.
+> **Iteration Guidance:** Mission command version — squad tasks state outcomes without prescribing layout or positioning. For scaffolded iterations, use [002-movement-to-contact-detailed.md](002-movement-to-contact-detailed.md).
 >
 > **See Also:** [LTA Grid Reference](../reference/lta-grid-reference.md)
->
-> **Iteration Guidance:** This is the mission command version — squad tasks state outcomes without prescribing specific positioning or movement. For the first iteration with a new class or candidates who need additional scaffolding, use [002-movement-to-contact-detailed.md](002-movement-to-contact-detailed.md) instead.
 
 **Time Zone Used Throughout the Plan/Order:** EASTERN STANDARD TIME
 
@@ -50,13 +40,13 @@ Platoon Sergeant
 ## 1. SITUATION
 
 ### a. Area of Interest
-The Camp Blanding LTA, Clay County, Florida. AO FLUNKER covers the central and eastern LTA — the Bradenton Avenue corridor, the FOB south entrance at OBJ HERRERA (MP 0612 1546), and Conex City — bounded north by Jacksonville Street, east by the FOB and Conex City perimeters, south by Arcadia Street, and west by Bradenton Avenue (vicinity MP 0600 1525 to MP 0615 1555). The area of interest extends west across Bradenton Avenue into the surrounding woodlines and south of Arcadia Street, where REAPER probing elements may withdraw to or stage from positions outside the LTA.
+AO FLUNKER occupies the central and eastern Camp Blanding LTA (vic MP 0600 1525 to MP 0615 1555), covering the Bradenton Ave corridor, the FOB south entrance at OBJ HERRERA (MP 0612 1546), and Conex City. Area of interest extends west across Bradenton Ave and south of Arcadia St, where REAPER probing elements may stage or withdraw.
 
 ### b. Area of Operations
 
-**1. Terrain.** The Camp Blanding LTA is a road-bounded sector of the training area, roughly 1,200m east-west by 550m north-south, set in flat sandy-soil pine and hardwood forest. An improved road grid frames the LTA: Bradenton Avenue (N-S) runs through the center, Clearwater Avenue (N-S) bounds the west, Arcadia Street (E-W) bounds the south, and Jacksonville Street (E-W) bounds the north. Two unnamed roads — one N-S in the western LTA and one E-W through the interior — subdivide the woodlines. The FOB sits at MP 0610 1550 in the northeast; Conex City sits at MP 0611 1530 in the southeast. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire and the primary mounted avenues of approach. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to the roads, particularly after rain.
+**1. Terrain.** The Camp Blanding LTA is a road-bounded ~1,200m × 550m sector of flat sandy-soil pine and hardwood forest. Improved road grid: Bradenton Ave (N-S, center), Clearwater Ave (N-S, west), Arcadia St (E-W, south), Jacksonville St (E-W, north); two unnamed roads (one N-S in the western LTA, one E-W through the interior) subdivide the woodlines. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to roads. See [LTA Grid Reference](../reference/lta-grid-reference.md) for full terrain notes.
 
-   - **Key Terrain:** The FOB south entrance (MP 0612 1546) controls access to the eastern sector from the south. The Bradenton/unnamed-road intersection (MP 0600 1538) anchors the central road grid and is a primary N-S avenue of approach. Conex City (MP 0611 1530) offers concealment and structures in the southeastern AO. Woodlines between Bradenton Avenue and Conex City provide covered E-W movement; visibility off road corridors is under 50m.
+   - **Key Terrain:** FOB south entrance (MP 0612 1546) controls eastern-sector access from the south; Bradenton/unnamed-road intersection (MP 0600 1538) anchors the central N-S avenue of approach; Conex City (MP 0611 1530) offers concealment and structures in the southeast. Woodlines between Bradenton Ave and Conex City provide covered E-W movement.
 
 **2. Weather.**
    - Skies: ________

--- a/STX/003-raid-a-bunker.md
+++ b/STX/003-raid-a-bunker.md
@@ -8,31 +8,21 @@
 >
 > **Complexity:** Lower to Moderate | **Recommended Phase:** WALK (Blocks 3-4), RUN (Day Iterations)
 >
-> **Mission Summary:** 1st Platoon conducts three independent squad raids on small REAPER nodes in AO HERRERA. Each squad destroys its own small target (OP, cache, or relay).
+> **Training Focus:** Evaluates **individual squad leader planning and decision-making**. The PL issues the platoon OPORD; each SL conducts their own TLP for a squad-sized raid — isolation, support, and assault elements within the squad. Assign one evaluator per squad.
 >
-> **Training Focus:** This OPORD is designed to evaluate **individual squad leader planning and decision-making**. The PL issues the platoon OPORD, but each squad leader must conduct their own TLP for a squad-sized raid — planning isolation, support, and assault elements within the squad. Cadre should assign one evaluator per squad to observe the SL's planning process and tactical decisions.
->
-> **Destinations:**
-> - 1st Squad → OBJ COTTO (vic MP 0600 1538) — small REAPER OP/cache at Bradenton intersection
-> - 2nd Squad → OBJ WHISKEY (vic MP 0613 1532) — small commo relay/cache in Conex City NE building
-> - 3rd Squad → OBJ ZULU (vic MP 0575 1524) — small REAPER OP at Arcadia / Clearwater intersection
->
-> **Actions on Objective:** Each squad independently moves to its own objective, destroys the small REAPER node (2-4 personnel), and consolidates. Squads do not depend on or wait for adjacent squads.
->
-> **Evaluation Timeline:** For evaluated iterations, candidates will receive this OPORD and have 75 minutes to complete TLP Steps 1-8 before SP. Execution window is 60 minutes. AAR is 15 minutes.
+> **Evaluation Timeline:** 75 min for TLP Steps 1-8 before SP. 60 min execution window. 15 min AAR.
 >
 > **OPFOR/Training Wrinkles:**
-> - Deploy one small REAPER node (2-4 personnel) per objective, operating independently.
+> - One small REAPER node (2-4 personnel) per objective, operating independently.
 > - Each node is a small OP, cache, or relay — NOT a fortified bunker. Squad-sized raid, not platoon.
-> - Introduce a civilian or non-combatant at one site to test ROE.
+> - Introduce a civilian at one site to test ROE.
 > - Cadre may inject counter-recon, early detection, or equipment malfunctions per site.
 > - If manning is limited, rotate one OPFOR team across sites between iterations.
+> - UAS/Counter-UAS injects are OPTIONAL and only if authorized by the Commandant and in the approved POI.
 >
-> **NOTE:** UAS/Counter-UAS injects are OPTIONAL and should only be used if authorized by the Commandant and incorporated into the approved POI.
+> **Iteration Guidance:** Mission command version — squad tasks state outcomes without prescribing layout or positioning. For scaffolded iterations, use [003-raid-a-bunker-detailed.md](003-raid-a-bunker-detailed.md).
 >
 > **See Also:** [LTA Grid Reference](../reference/lta-grid-reference.md)
->
-> **Iteration Guidance:** This is the mission command version — squad tasks state outcomes without prescribing specific positioning or movement. For the first iteration with a new class or candidates who need additional scaffolding, use [003-raid-a-bunker-detailed.md](003-raid-a-bunker-detailed.md) instead.
 
 **Time Zone Used Throughout the Plan/Order:** EASTERN STANDARD TIME
 
@@ -50,13 +40,13 @@ Platoon Sergeant
 ## 1. SITUATION
 
 ### a. Area of Interest
-The Camp Blanding LTA, Clay County, Florida. AO HERRERA is the Bradenton Avenue corridor between Arcadia Street (south) and Jacksonville Street (north), bounded west by Clearwater Avenue and east by the FOB and Conex City perimeters (vicinity MP 0575 1523 to MP 0615 1565). The area of interest extends north along Bradenton Avenue past Jacksonville Street, where REAPER could reinforce the bunker after contact, and south of Arcadia Street into the broader training area — the likely REAPER withdrawal corridor.
+AO HERRERA occupies the Bradenton Ave corridor of the Camp Blanding LTA (vic MP 0575 1523 to MP 0615 1565), bounded by Jacksonville St (N), Arcadia St (S), Clearwater Ave (W), and the FOB/Conex City perimeters (E). Area of interest extends north past Jacksonville St (potential REAPER reinforcement) and south of Arcadia St (likely withdrawal corridor).
 
 ### b. Area of Operations
 
-**1. Terrain.** The Camp Blanding LTA is a road-bounded sector of the training area, roughly 1,200m east-west by 550m north-south, set in flat sandy-soil pine and hardwood forest. An improved road grid frames the LTA: Bradenton Avenue (N-S) runs through the center, Clearwater Avenue (N-S) bounds the west, Arcadia Street (E-W) bounds the south, and Jacksonville Street (E-W) bounds the north. Two unnamed roads — one N-S in the western LTA and one E-W through the interior — subdivide the woodlines. The FOB sits at MP 0610 1550 in the northeast; Conex City sits at MP 0611 1530 in the southeast. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire and the primary mounted avenues of approach. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to the roads, particularly after rain.
+**1. Terrain.** The Camp Blanding LTA is a road-bounded ~1,200m × 550m sector of flat sandy-soil pine and hardwood forest. Improved road grid: Bradenton Ave (N-S, center), Clearwater Ave (N-S, west), Arcadia St (E-W, south), Jacksonville St (E-W, north); two unnamed roads (one N-S in the western LTA, one E-W through the interior) subdivide the woodlines. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to roads. See [LTA Grid Reference](../reference/lta-grid-reference.md) for full terrain notes.
 
-   - **Key Terrain:** The Bradenton Avenue / unnamed east-west road intersection is a key crossroads in the central AO. The Conex City northeast building provides cover and concealment in the eastern built-up area. The Arcadia Street / Clearwater Avenue junction in the southwestern AO controls movement through that sector. Woodlines surrounding each location provide concealed avenues of approach for dismounted elements.
+   - **Key Terrain:** Bradenton Ave / unnamed E-W road intersection (central crossroads); Conex City NE building (cover/concealment in the eastern built-up area, MP 0611 1530); Arcadia St / Clearwater Ave junction (controls southwestern movement). Surrounding woodlines provide concealed dismounted approaches to each.
 
 **2. Weather.**
    - Skies: ________

--- a/STX/004-clear-dismount-city.md
+++ b/STX/004-clear-dismount-city.md
@@ -8,27 +8,20 @@
 >
 > **Complexity:** Highest | **Recommended Phase:** RUN (Advanced Iterations - Second Cycle or High Performers)
 >
-> **Mission Summary:** 1st Platoon is tasked to clear, seize, and secure the urban terrain known as OBJ FLUNKER. REAPER forces are using this area as a base for operations. The platoon must occupy the city and prevent REAPER from regaining control or using it for future operations.
+> **Training Focus:** Highest complexity due to MOUT operations. Recommend for second-cycle iterations or candidates demonstrating strong TLP proficiency. Requires detailed planning for building clearing, phase lines, and consolidation. Assign one evaluator per squad.
 >
-> **Destination:** OBJ FLUNKER, AO HERRERA (urban terrain, grid MP 0611 1530).
->
-> **Actions on Objective:** Platoon will establish an ORP, move to the city, isolate the objective, clear buildings and key terrain, secure the area, and establish defensive positions to prevent enemy re-infiltration. Assault, support, and security elements will be employed per doctrine.
->
-> **Training Focus:** This OPORD has the highest complexity due to MOUT operations. Recommend for second cycle iterations or candidates demonstrating strong TLP proficiency. Requires detailed planning for building clearing, phase lines, and consolidation.
->
-> **Evaluation Timeline:** For evaluated iterations, candidates will receive this OPORD and have 75 minutes to complete TLP Steps 1-8 before SP. Execution window is 60 minutes. AAR is 15 minutes.
+> **Evaluation Timeline:** 75 min for TLP Steps 1-8 before SP. 60 min execution window. 15 min AAR.
 >
 > **OPFOR/Training Wrinkles:**
 > - Simulate a determined defense using urban tactics, barricades, and possible IEDs.
 > - Introduce non-combatant role-players, civilian presence, or hostages to test ROE.
-> - OPFOR may attempt to counterattack, infiltrate, or use underground routes.
+> - OPFOR may counterattack, infiltrate, or use underground routes.
 > - Inject time-sensitive intelligence, booby traps, or unexpected obstacles.
+> - UAS/Counter-UAS injects are OPTIONAL and only if authorized by the Commandant and in the approved POI.
 >
-> **NOTE:** UAS/Counter-UAS injects are OPTIONAL and should only be used if authorized by the Commandant and incorporated into the approved POI.
+> **Iteration Guidance:** Mission command version — squad tasks state outcomes without prescribing layout or positioning. For scaffolded iterations, use [004-clear-dismount-city-detailed.md](004-clear-dismount-city-detailed.md).
 >
 > **See Also:** [LTA Grid Reference](../reference/lta-grid-reference.md)
->
-> **Iteration Guidance:** This is the mission command version — squad tasks state outcomes without prescribing specific positioning or movement. For the first iteration with a new class or candidates who need additional scaffolding, use [004-clear-dismount-city-detailed.md](004-clear-dismount-city-detailed.md) instead.
 
 **Time Zone Used Throughout the Plan/Order:** EASTERN STANDARD TIME
 
@@ -46,13 +39,13 @@ Platoon Sergeant
 ## 1. SITUATION
 
 ### a. Area of Interest
-The Camp Blanding LTA, Clay County, Florida. AO FLUNKER is centered on Conex City (MP 0611 1530), a built-up training facsimile in the southeastern LTA, bounded north by the unnamed east-west road, west by Bradenton Avenue, south by Arcadia Street, and east by the LTA perimeter (vicinity MP 0600 1525 to MP 0615 1540). The area of interest extends west into the woodlines between Bradenton Avenue and Conex City, where REAPER may emplace overwatch positions, and south of Arcadia Street into the broader training area — the likely REAPER withdrawal corridor.
+AO FLUNKER is centered on Conex City (MP 0611 1530) in the southeastern Camp Blanding LTA (vic MP 0600 1525 to MP 0615 1540). Area of interest extends west into the woodlines between Bradenton Ave and Conex City (potential REAPER overwatch) and south of Arcadia St into the broader training area — the likely REAPER withdrawal corridor.
 
 ### b. Area of Operations
 
-**1. Terrain.** The Camp Blanding LTA is a road-bounded sector of the training area, roughly 1,200m east-west by 550m north-south, set in flat sandy-soil pine and hardwood forest. An improved road grid frames the LTA: Bradenton Avenue (N-S) runs through the center, Clearwater Avenue (N-S) bounds the west, Arcadia Street (E-W) bounds the south, and Jacksonville Street (E-W) bounds the north. The FOB sits at MP 0610 1550 in the northeast; Conex City sits at MP 0611 1530 in the southeast. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors. OBJ FLUNKER is the Conex City site itself — a cluster of one- and two-story Conex-style structures with narrow lanes between buildings and small open spaces, role-played for this scenario as a small urban district with notional civil structures (residences, police station, central plaza, higher-elevation building). The site provides multiple positions for defense, ambush, and concealment; Bradenton Avenue west of the site is the only mounted avenue of approach.
+**1. Terrain.** The Camp Blanding LTA is a road-bounded ~1,200m × 550m sector of flat sandy-soil pine and hardwood forest. Improved road grid: Bradenton Ave (N-S, center), Clearwater Ave (N-S, west), Arcadia St (E-W, south), Jacksonville St (E-W, north); two unnamed roads (one N-S in the western LTA, one E-W through the interior) subdivide the woodlines. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to roads. OBJ FLUNKER is the Conex City site itself — a cluster of one- and two-story Conex-style structures with narrow lanes and small open spaces, role-played as a small urban district with notional civil structures (residences, police station, central plaza, higher-elevation building). See [LTA Grid Reference](../reference/lta-grid-reference.md) for full terrain notes.
 
-   - **Key Terrain:** The Conex City center (MP 0611 1530, role-played as the central plaza and civil structures) and the northeast building (MP 0613 1532, role-played as the higher-elevation observation building) dominate OBJ FLUNKER and are critical for control. Rooftops of the Conex structures and the lanes between them provide observation and limited fields of fire. The Bradenton Avenue corridor west of the site and Arcadia Street to the south are the likely avenues of approach and withdrawal.
+   - **Key Terrain:** Conex City center (MP 0611 1530, central plaza and civil structures) and the NE building (MP 0613 1532, higher-elevation observation) dominate OBJ FLUNKER. Rooftops and inter-building lanes provide observation and limited fields of fire. Bradenton Ave (W) and Arcadia St (S) are the likely avenues of approach and withdrawal.
 
 **2. Weather.**
    - Skies: ________

--- a/STX/005-area-zone-reconnaissance.md
+++ b/STX/005-area-zone-reconnaissance.md
@@ -8,28 +8,21 @@
 >
 > **Complexity:** Lower | **Recommended Phase:** WALK (Blocks 1-2), RUN (Day Iterations)
 >
-> **Mission Summary:** 1st Platoon is tasked to conduct an area reconnaissance in AO COTTO to locate REAPER positions, assess REAPER strength and disposition, and identify key terrain features.
+> **Training Focus:** Early TLP training — simpler mission focus lets candidates concentrate on planning products, reconnaissance fundamentals, and reporting without the complexity of direct engagement. Assign one evaluator per squad.
 >
-> **Destination:** AO COTTO, central and eastern Camp Blanding LTA — bounded by Jacksonville Street (north), Arcadia Street (south), Conex City and FOB perimeter (east), and Bradenton Avenue (west). Focus area around suspected REAPER position at MP 0613 1532 (Conex City NE building).
->
-> **Actions on Objective:** Platoon will establish an ORP, conduct reconnaissance of the area using zone or area reconnaissance techniques, collect intelligence on enemy positions and activities, and report findings to higher headquarters.
->
-> **Training Focus:** This OPORD is ideal for early TLP training due to its simpler mission focus. Candidates can concentrate on planning products, reconnaissance fundamentals, and reporting without the added complexity of direct engagement.
->
-> **Evaluation Timeline:** For evaluated iterations, candidates will receive this OPORD and have 75 minutes to complete TLP Steps 1-8 before SP. Execution window is 60 minutes. AAR is 15 minutes.
+> **Evaluation Timeline:** 75 min for TLP Steps 1-8 before SP. 60 min execution window. 15 min AAR.
 >
 > **OPFOR/Training Wrinkles:**
 > - Enemy may be static in defensive positions or mobile in small patrols.
-> - Introduce false indicators or decoy positions to test candidate's analytical skills.
-> - OPFOR may detect friendly reconnaissance and attempt to counter-recon or withdraw.
-> - Cadre can inject time constraints, weather changes, or equipment failures.
+> - False indicators or decoy positions to test analytical skills.
+> - OPFOR may detect friendly reconnaissance and attempt counter-recon or withdrawal.
+> - Cadre may inject time constraints, weather changes, or equipment failures.
 > - Test ability to avoid detection while gathering intelligence.
+> - UAS/Counter-UAS injects are OPTIONAL and only if authorized by the Commandant and in the approved POI.
 >
-> **NOTE:** UAS/Counter-UAS injects are OPTIONAL and should only be used if authorized by the Commandant and incorporated into the approved POI.
+> **Iteration Guidance:** Mission command version — squad tasks state outcomes without prescribing layout or positioning. For scaffolded iterations, use [005-area-zone-reconnaissance-detailed.md](005-area-zone-reconnaissance-detailed.md).
 >
 > **See Also:** [LTA Grid Reference](../reference/lta-grid-reference.md)
->
-> **Iteration Guidance:** This is the mission command version — squad tasks state outcomes without prescribing specific positioning or movement. For the first iteration with a new class or candidates who need additional scaffolding, use [005-area-zone-reconnaissance-detailed.md](005-area-zone-reconnaissance-detailed.md) instead.
 
 **Time Zone Used Throughout the Plan/Order:** EASTERN STANDARD TIME
 
@@ -47,13 +40,13 @@ Platoon Sergeant
 ## 1. SITUATION
 
 ### a. Area of Interest
-The Camp Blanding LTA, Clay County, Florida. AO COTTO covers the central and eastern LTA, with suspected REAPER activity centered on Conex City northeast building (MP 0613 1532), bounded north by Jacksonville Street, east by Conex City and the FOB perimeter, south by Arcadia Street, and west by Bradenton Avenue (vicinity MP 0600 1525 to MP 0615 1565). The area of interest extends west across Bradenton Avenue and south of Arcadia Street into the woodlines that connect the eastern LTA to suspected REAPER support positions and lines of communication outside the AO.
+AO COTTO covers the central and eastern Camp Blanding LTA (vic MP 0600 1525 to MP 0615 1565), with suspected REAPER activity centered on the Conex City NE building (MP 0613 1532). Area of interest extends west across Bradenton Ave and south of Arcadia St into the woodlines that connect to suspected REAPER support positions and lines of communication outside the AO.
 
 ### b. Area of Operations
 
-**1. Terrain.** The Camp Blanding LTA is a road-bounded sector of the training area, roughly 1,200m east-west by 550m north-south, set in flat sandy-soil pine and hardwood forest. An improved road grid frames the LTA: Bradenton Avenue (N-S) runs through the center, Clearwater Avenue (N-S) bounds the west, Arcadia Street (E-W) bounds the south, and Jacksonville Street (E-W) bounds the north. Two unnamed roads — one N-S in the western LTA and one E-W through the interior — subdivide the woodlines. The FOB sits at MP 0610 1550 in the northeast; Conex City sits at MP 0611 1530 in the southeast. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire and the primary mounted avenues of approach. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to the roads, particularly after rain.
+**1. Terrain.** The Camp Blanding LTA is a road-bounded ~1,200m × 550m sector of flat sandy-soil pine and hardwood forest. Improved road grid: Bradenton Ave (N-S, center), Clearwater Ave (N-S, west), Arcadia St (E-W, south), Jacksonville St (E-W, north); two unnamed roads (one N-S in the western LTA, one E-W through the interior) subdivide the woodlines. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to roads. See [LTA Grid Reference](../reference/lta-grid-reference.md) for full terrain notes.
 
-   - **Key Terrain:** The suspected REAPER position at MP 0613 1532 is the focus of reconnaissance. The area north and south of the objective is relatively open, limiting observation positions. Woodlines to the east and west provide concealment for reconnaissance elements approaching the objective.
+   - **Key Terrain:** Suspected REAPER position at MP 0613 1532 (focus of reconnaissance). Area north and south of the objective is relatively open, limiting observation positions; woodlines east and west provide concealed approach for reconnaissance elements.
 
 **2. Weather.**
    - Skies: ________

--- a/STX/008-patrol-base-operations.md
+++ b/STX/008-patrol-base-operations.md
@@ -8,29 +8,21 @@
 >
 > **Complexity:** Moderate | **Recommended Phase:** RUN (Night Iterations - Coaching Focus)
 >
-> **Mission Summary:** 1st Platoon is tasked to establish and occupy a patrol base in AO COTTO to conduct continuous operations, provide security, and enable sustainment for follow-on missions.
+> **Training Focus:** Emphasizes security priorities, patrol base setup, and sustainment operations. Links to the Patrol Base Operations Training Package. Ideal for night iterations where static operations allow focus on security fundamentals. Assign one evaluator per squad.
 >
-> **Destination:** Patrol Base (PB) THUNDER, vicinity MP 0580 1520, AO COTTO, NLT 2200.
->
-> **Actions on Objective:** Platoon will conduct a leader's reconnaissance, occupy the patrol base using the triangle or cigar-shaped technique, establish security, and conduct patrol base activities including security patrols, maintenance, and planning for follow-on operations.
->
-> **Training Focus:** This OPORD emphasizes security priorities, patrol base setup, and sustainment operations. Links directly to the Patrol Base Operations Training Package. Ideal for night training iterations where static operations allow focus on security fundamentals without the complexity of offensive maneuver.
->
-> **Evaluation Timeline:** For evaluated iterations, candidates will receive this OPORD and have 75 minutes to complete TLP Steps 1-8 before SP. Execution window is 60 minutes. AAR is 15 minutes.
+> **Evaluation Timeline:** 75 min for TLP Steps 1-8 before SP. 60 min execution window. 15 min AAR.
 >
 > **OPFOR/Training Wrinkles:**
-> - Simulate enemy reconnaissance probes during occupation or stand-to.
-> - Test candidate's ability to establish and maintain security priorities.
-> - Introduce resupply, casualty evacuation, or personnel issues during occupation.
-> - Cadre can inject intelligence updates requiring adjustment to the patrol base plan.
-> - Test ability to conduct patrol base activities while maintaining security.
-> - Introduce a compromise scenario requiring displacement or defense.
+> - Enemy reconnaissance probes during occupation or stand-to.
+> - Tests ability to establish and maintain security priorities.
+> - Resupply, casualty evacuation, or personnel issues during occupation.
+> - Intelligence updates requiring adjustment to the patrol base plan.
+> - Compromise scenario requiring displacement or defense.
+> - UAS/Counter-UAS injects are OPTIONAL and only if authorized by the Commandant and in the approved POI.
 >
-> **NOTE:** UAS/Counter-UAS injects are OPTIONAL and should only be used if authorized by the Commandant and incorporated into the approved POI.
+> **Iteration Guidance:** Mission command version — squad tasks state outcomes without prescribing layout or positioning. For scaffolded iterations, use [008-patrol-base-operations-detailed.md](008-patrol-base-operations-detailed.md).
 >
 > **See Also:** [LTA Grid Reference](../reference/lta-grid-reference.md)
->
-> **Iteration Guidance:** This is the mission command version — squad tasks state outcomes without prescribing specific positioning or movement. For the first iteration with a new class or candidates who need additional scaffolding, use [008-patrol-base-operations-detailed.md](008-patrol-base-operations-detailed.md) instead.
 
 **Time Zone Used Throughout the Plan/Order:** EASTERN STANDARD TIME
 
@@ -48,13 +40,13 @@ Platoon Sergeant
 ## 1. SITUATION
 
 ### a. Area of Interest
-The Camp Blanding LTA, Clay County, Florida. AO COTTO covers the southwestern LTA in the woodlines south of the unnamed east-west road and west of Bradenton Avenue, with PB THUNDER planned at MP 0580 1520 (vicinity MP 0575 1518 to MP 0600 1540). The area of interest extends north toward the FOB at MP 0610 1550 (higher headquarters), south of Arcadia Street into the broader Camp Blanding training area, and east across Bradenton Avenue — the corridors REAPER patrols could use to detect, compromise, or attack the patrol base.
+AO COTTO covers the southwestern Camp Blanding LTA in the woodlines south of the unnamed E-W road and west of Bradenton Ave, with PB THUNDER planned at MP 0580 1520 (vic MP 0575 1518 to MP 0600 1540). Area of interest extends north toward the FOB at MP 0610 1550 (higher), south of Arcadia St into the broader training area, and east across Bradenton Ave — the corridors REAPER patrols could use to detect, compromise, or attack the patrol base.
 
 ### b. Area of Operations
 
-**1. Terrain.** The Camp Blanding LTA is a road-bounded sector of the training area, roughly 1,200m east-west by 550m north-south, set in flat sandy-soil pine and hardwood forest. An improved road grid frames the LTA: Bradenton Avenue (N-S) runs through the center, Clearwater Avenue (N-S) bounds the west, Arcadia Street (E-W) bounds the south, and Jacksonville Street (E-W) bounds the north. Two unnamed roads — one N-S in the western LTA and one E-W through the interior — subdivide the woodlines. The FOB sits at MP 0610 1550 in the northeast; Conex City sits at MP 0611 1530 in the southeast. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire and the primary mounted avenues of approach. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to the roads, particularly after rain.
+**1. Terrain.** The Camp Blanding LTA is a road-bounded ~1,200m × 550m sector of flat sandy-soil pine and hardwood forest. Improved road grid: Bradenton Ave (N-S, center), Clearwater Ave (N-S, west), Arcadia St (E-W, south), Jacksonville St (E-W, north); two unnamed roads (one N-S in the western LTA, one E-W through the interior) subdivide the woodlines. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to roads. See [LTA Grid Reference](../reference/lta-grid-reference.md) for full terrain notes.
 
-   - **Key Terrain:** The planned patrol base site at MP 0580 1520 offers good concealment, defensible terrain, and access to covered withdrawal routes. The surrounding woodlines provide observation points for early warning. A small creek to the south provides a water source but may also canalize enemy approach. Elevated ground to the north offers observation of likely enemy avenues of approach.
+   - **Key Terrain:** Planned patrol base site at MP 0580 1520 (concealment, defensible terrain, covered withdrawal routes). Surrounding woodlines provide observation points for early warning. Small creek to the south is a water source but may canalize enemy approach. Elevated ground to the north offers observation of likely avenues of approach.
 
 **2. Weather.**
    - Skies: ________

--- a/STX/009-tactical-road-march.md
+++ b/STX/009-tactical-road-march.md
@@ -8,29 +8,21 @@
 >
 > **Complexity:** Lower | **Recommended Phase:** WALK (Blocks 1-2), RUN (Day Iterations)
 >
-> **Mission Summary:** 1st Platoon is tasked to conduct a tactical road march from the assembly area to a designated release point in order to position the platoon for follow-on operations.
+> **Training Focus:** Early TLP training — straightforward mission lets candidates concentrate on movement planning, order of march, security during movement, and actions at halts. Good introduction to terrain association and route planning. Assign one evaluator per squad.
 >
-> **Destination:** Release Point (RP) THUNDER at MP 0615 1560, AO COTTO.
->
-> **Actions on Objective:** Platoon will conduct a tactical road march using appropriate movement formations and techniques, maintain security throughout movement, conduct security halts as required, and arrive at the release point prepared for follow-on operations.
->
-> **Training Focus:** This OPORD is ideal for early TLP training due to its straightforward mission focus. Candidates concentrate on movement planning, order of march, security during movement, and actions at halts without the complexity of actions on the objective. Good introduction to terrain association and route planning.
->
-> **Evaluation Timeline:** For evaluated iterations, candidates will receive this OPORD and have 75 minutes to complete TLP Steps 1-8 before SP. Execution window is 60 minutes. AAR is 15 minutes.
+> **Evaluation Timeline:** 75 min for TLP Steps 1-8 before SP. 60 min execution window. 15 min AAR.
 >
 > **OPFOR/Training Wrinkles:**
-> - Introduce unexpected obstacles or route changes requiring alternate route selection.
-> - Simulate enemy reconnaissance or contact during movement to test security procedures.
-> - Inject equipment failures, casualties, or stragglers during movement.
-> - Test actions at danger areas (road crossings, open areas, water obstacles).
-> - Cadre can inject time constraints or priority changes to test adaptability.
-> - Test candidate's ability to maintain accountability and control during extended movement.
+> - Unexpected obstacles or route changes requiring alternate route selection.
+> - Enemy reconnaissance or contact during movement to test security procedures.
+> - Equipment failures, casualties, or stragglers during movement.
+> - Actions at danger areas (road crossings, open areas, water obstacles).
+> - Time constraints or priority changes to test adaptability.
+> - UAS/Counter-UAS injects are OPTIONAL and only if authorized by the Commandant and in the approved POI.
 >
-> **NOTE:** UAS/Counter-UAS injects are OPTIONAL and should only be used if authorized by the Commandant and incorporated into the approved POI.
+> **Iteration Guidance:** Mission command version — squad tasks state outcomes without prescribing layout or positioning. For scaffolded iterations, use [009-tactical-road-march-detailed.md](009-tactical-road-march-detailed.md).
 >
 > **See Also:** [LTA Grid Reference](../reference/lta-grid-reference.md)
->
-> **Iteration Guidance:** This is the mission command version — squad tasks state outcomes without prescribing specific positioning or movement. For the first iteration with a new class or candidates who need additional scaffolding, use [009-tactical-road-march-detailed.md](009-tactical-road-march-detailed.md) instead.
 
 **Time Zone Used Throughout the Plan/Order:** EASTERN STANDARD TIME
 
@@ -48,13 +40,13 @@ Platoon Sergeant
 ## 1. SITUATION
 
 ### a. Area of Interest
-The Camp Blanding LTA, Clay County, Florida. AO COTTO covers the central and northeastern LTA along the platoon's route of march from the FOB (SP at MP 0610 1550) to RP THUNDER (MP 0615 1560), bounded north by Jacksonville Street, west by Bradenton Avenue, south by the unnamed east-west road, and east by the LTA perimeter. The area of interest extends west across Bradenton Avenue and north past Jacksonville Street into the woodlines flanking the route, where REAPER observation or interdiction elements could disrupt the platoon's movement before reaching the RP.
+AO COTTO covers the central and northeastern Camp Blanding LTA along the platoon's route of march from the FOB (SP at MP 0610 1550) to RP THUNDER (MP 0615 1560). Area of interest extends west across Bradenton Ave and north past Jacksonville St into the woodlines flanking the route, where REAPER observation or interdiction elements could disrupt the platoon's movement before reaching the RP.
 
 ### b. Area of Operations
 
-**1. Terrain.** The Camp Blanding LTA is a road-bounded sector of the training area, roughly 1,200m east-west by 550m north-south, set in flat sandy-soil pine and hardwood forest. An improved road grid frames the LTA: Bradenton Avenue (N-S) runs through the center, Clearwater Avenue (N-S) bounds the west, Arcadia Street (E-W) bounds the south, and Jacksonville Street (E-W) bounds the north. Two unnamed roads — one N-S in the western LTA and one E-W through the interior — subdivide the woodlines. The FOB sits at MP 0610 1550 in the northeast; Conex City sits at MP 0611 1530 in the southeast. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire and the primary mounted avenues of approach. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to the roads, particularly after rain.
+**1. Terrain.** The Camp Blanding LTA is a road-bounded ~1,200m × 550m sector of flat sandy-soil pine and hardwood forest. Improved road grid: Bradenton Ave (N-S, center), Clearwater Ave (N-S, west), Arcadia St (E-W, south), Jacksonville St (E-W, north); two unnamed roads (one N-S in the western LTA, one E-W through the interior) subdivide the woodlines. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to roads. See [LTA Grid Reference](../reference/lta-grid-reference.md) for full terrain notes.
 
-   - **Key Terrain:** The route of march includes several danger areas: a road crossing at MP 0605 1545, an open area near MP 0608 1550, and a creek crossing at MP 0612 1555. RP THUNDER at MP 0615 1560 provides good concealment and defensible terrain for the transition to follow-on operations.
+   - **Key Terrain:** Route of march includes danger areas at a road crossing (MP 0605 1545), an open area (MP 0608 1550), and a creek crossing (MP 0612 1555). RP THUNDER (MP 0615 1560) offers concealment and defensible terrain for the transition to follow-on operations.
 
 **2. Weather.**
    - Skies: ________

--- a/STX/010-dsca-convoy-operations.md
+++ b/STX/010-dsca-convoy-operations.md
@@ -8,23 +8,21 @@
 >
 > **Complexity:** Moderate | **Recommended Phase:** WALK (Blocks 2-3), RUN (Day Iterations)
 >
-> **Mission Summary:** A Company conducts logistics convoy operations from Camp Blanding Joint Training Center to Bay County, FL to deliver emergency relief supplies in support of Hurricane DELTA relief operations. 1st Platoon is tasked to execute the convoy.
+> **Training Focus:** Company-level OPORD. Candidates receive this as the 1st Platoon Leader and conduct TLP to plan their platoon's execution. Focus areas: route planning, convoy organization, contingency planning, and decision-making in degraded infrastructure environments.
 >
-> **Training Focus:** This is a COMPANY-LEVEL OPORD. Candidates receive this order as the 1st Platoon Leader and must conduct TLP to plan their platoon's execution of the convoy mission. Focus areas include route planning, convoy organization, contingency planning, and decision-making in degraded infrastructure environments.
->
-> **Evaluation Timeline:** Candidates will receive this OPORD and have 75 minutes to complete TLP Steps 1-8. Candidates will brief their platoon order to cadre. This is a planning exercise only.
+> **Evaluation Timeline:** 75 min for TLP Steps 1-8. Candidates brief their platoon order to cadre. Planning exercise only.
 >
 > **Training Wrinkles (for candidate planning consideration):**
-> - Power outages causing traffic signals to be inoperable.
+> - Power outages with inoperable traffic signals.
 > - Fuel stations empty or inoperable due to civilian run on fuel.
-> - Blocked routes requiring immediate rerouting decisions.
+> - Blocked routes requiring immediate rerouting.
 > - Vehicle breakdown requiring recovery procedures.
 > - Civilians flagging down convoy requesting assistance.
 > - Debris on roadway requiring clearance or bypass.
 > - Communication dead zones.
 > - Evacuee traffic causing congestion on primary routes.
 >
-> **NOTE:** This is a DSCA operation. There is no enemy threat.
+> **NOTE:** DSCA operation — no enemy threat.
 
 **CLASSIFICATION: UNCLASSIFIED // FOR TRAINING USE ONLY**
 

--- a/STX/011-dsca-mounted-reconnaissance.md
+++ b/STX/011-dsca-mounted-reconnaissance.md
@@ -8,14 +8,12 @@
 >
 > **Complexity:** Moderate | **Recommended Phase:** WALK (Blocks 2-3), RUN (Day Iterations)
 >
-> **Mission Summary:** A Company conducts mounted reconnaissance operations in Bay County to assess damage, identify hazards, and report conditions to enable follow-on relief operations. 1st Platoon is tasked to reconnoiter the US-231 corridor and Panama City urban area.
+> **Training Focus:** Company-level OPORD. Candidates receive this as the 1st Platoon Leader and conduct TLP to plan their platoon's reconnaissance. Focus areas: reconnaissance planning, systematic observation, accurate reporting, and information management.
 >
-> **Training Focus:** This is a COMPANY-LEVEL OPORD. Candidates receive this order as the 1st Platoon Leader and must conduct TLP to plan their platoon's reconnaissance operations. Focus areas include reconnaissance planning, systematic observation, accurate reporting, and information management.
->
-> **Evaluation Timeline:** Candidates will receive this OPORD and have 75 minutes to complete TLP Steps 1-8. Candidates will brief their platoon order to cadre. This is a planning exercise only.
+> **Evaluation Timeline:** 75 min for TLP Steps 1-8. Candidates brief their platoon order to cadre. Planning exercise only.
 >
 > **Training Wrinkles (for candidate planning consideration):**
-> - Power outages causing traffic signals to be inoperable.
+> - Power outages with inoperable traffic signals.
 > - Fuel stations empty or inoperable.
 > - Blocked routes requiring rerouting and assessment.
 > - Damaged bridges requiring trafficability assessment (GO/NO-GO).
@@ -26,7 +24,7 @@
 > - Local officials requesting immediate reconnaissance of specific areas.
 > - Media presence.
 >
-> **NOTE:** This is a DSCA operation. There is no enemy threat. Reconnaissance focuses on infrastructure and conditions.
+> **NOTE:** DSCA operation — no enemy threat. Reconnaissance focuses on infrastructure and conditions.
 
 **CLASSIFICATION: UNCLASSIFIED // FOR TRAINING USE ONLY**
 

--- a/STX/012-dsca-point-of-distribution.md
+++ b/STX/012-dsca-point-of-distribution.md
@@ -8,11 +8,9 @@
 >
 > **Complexity:** Moderate | **Recommended Phase:** WALK (Blocks 2-3), RUN (Day/Night Iterations)
 >
-> **Mission Summary:** A Company establishes and operates multiple Points of Distribution (PODs) in Bay County to distribute emergency supplies to affected civilians. 1st Platoon is tasked to operate POD Site ALPHA.
+> **Training Focus:** Company-level OPORD. Candidates receive this as the 1st Platoon Leader and conduct TLP to plan their platoon's POD operations. Focus areas: site organization, traffic flow, supply management, personnel allocation, and contingency planning for civilian interactions.
 >
-> **Training Focus:** This is a COMPANY-LEVEL OPORD. Candidates receive this order as the 1st Platoon Leader and must conduct TLP to plan their platoon's POD operations. Focus areas include site organization, traffic flow, supply management, personnel allocation, and contingency planning for civilian interactions.
->
-> **Evaluation Timeline:** Candidates will receive this OPORD and have 75 minutes to complete TLP Steps 1-8. Candidates will brief their platoon order to cadre. This is a planning exercise only.
+> **Evaluation Timeline:** 75 min for TLP Steps 1-8. Candidates brief their platoon order to cadre. Planning exercise only.
 >
 > **Training Wrinkles (for candidate planning consideration):**
 > - Supplies running low before scheduled resupply.
@@ -27,7 +25,7 @@
 > - Vehicle breakdown blocking distribution lane.
 > - Other agencies arriving to coordinate.
 >
-> **NOTE:** This is a DSCA operation. Security awareness is important due to supplies and stressed population, but there is no enemy threat.
+> **NOTE:** DSCA operation — no enemy threat, but security awareness is important due to supplies and stressed population.
 
 **CLASSIFICATION: UNCLASSIFIED // FOR TRAINING USE ONLY**
 

--- a/STX/014-deliberate-attack.md
+++ b/STX/014-deliberate-attack.md
@@ -8,21 +8,20 @@
 >
 > **Complexity:** Moderate | **Recommended Phase:** CRAWL (Practical Exercise), WALK (Blocks 1-2), RUN (Day Iterations)
 >
-> **Mission Summary:** 1st Platoon is tasked to attack to destroy the REAPER forward command post at OBJ HERRERA and disrupt enemy command and control in AO COTTO.
+> **Training Focus:** Dual-role OPORD. For CRAWL phase, the TAC briefs the order paragraph by paragraph to teach extraction of planning information. For WALK/RUN, it is a standalone evaluated lane — a deliberate attack against an enemy CP. The CP objective adds complexity beyond a simple terrain seizure: candidates must plan for intelligence collection (SSE) after assault. Assign one evaluator per squad.
 >
-> **Destination:** OBJ HERRERA at MP 0600 1523, AO COTTO.
+> **Evaluation Timeline:** 75 min for TLP Steps 1-8 before SP. 60 min execution window. 15 min AAR.
 >
-> **Actions on Objective:** Platoon will establish an ORP, conduct leader's reconnaissance, move to assault positions, seize the objective, conduct a hasty sensitive site exploitation (SSE), and consolidate.
+> **OPFOR/Training Wrinkles:**
+> - 3-4 REAPER per iteration: 1-2 CP staff (seated at field desk with maps/radios), 2 in fighting positions around the CP.
+> - Props: field desk or table, antenna simulator (pole with wire), map boards, radio. CP staff attempt to destroy documents if given time during the assault.
+> - OP variant: replace CP with a 2-4 person observation post; remove the SSE task and CP staff. Emphasize stealth approach and speed — the OP's priority is transmitting a report before being overrun. Equip with binoculars, radio, sketch of friendly positions.
+> - See [OPFOR Card](014-deliberate-attack-opfor.md) for full details.
+> - UAS/Counter-UAS injects are OPTIONAL and only if authorized by the Commandant and in the approved POI.
 >
-> **Training Focus:** This OPORD serves dual roles. For CRAWL phase, the TAC briefs this order paragraph by paragraph, pausing at each section to explain what information the candidate should extract and how it feeds into their planning. For WALK/RUN iterations, it is a standalone evaluated lane — a deliberate attack against an enemy command post. Candidates should be able to identify: specified tasks, implied tasks, commander's intent, and key control measures. The CP objective adds complexity beyond a simple terrain seizure: candidates must plan for intelligence collection (SSE) after assault.
->
-> **OPFOR/Training Wrinkles:** For WALK/RUN iterations, OPFOR presents 3-4 personnel: 1-2 acting as CP staff (seated at field desk with maps/radios) and 2 in fighting positions around the CP. The reduced force size keeps the assault manageable for a single squad. Props recommended: field desk or table, antenna simulator (pole with wire), map boards, and a radio. CP staff should attempt to destroy documents if given time during the assault. See [OPFOR Card](014-deliberate-attack-opfor.md) for full details.
->
-> **OP Variant:** For iterations requiring a "deliberate attack on enemy OP," replace the CP with a 2-4 person observation post. Remove the SSE task and CP staff from OPFOR. Emphasize stealth approach and speed of assault — the OP's value is early warning, so the enemy's priority is transmitting a report before being overrun. Adjust enemy composition to 2-4 REAPER with binoculars, radio, and a sketch of friendly positions.
+> **Iteration Guidance:** Mission command version — squad tasks state outcomes without prescribing layout or positioning. For scaffolded iterations, use [014-deliberate-attack-detailed.md](014-deliberate-attack-detailed.md). For a classroom walkthrough of the TLP steps applied to this OPORD, see [014 Walkthrough](014-deliberate-attack-walkthrough.md).
 >
 > **See Also:** [LTA Grid Reference](../reference/lta-grid-reference.md) | [Tactical Overlay](014-deliberate-attack-overlay.html) | [Walkthrough](014-deliberate-attack-walkthrough.md) | [OPFOR Card](014-deliberate-attack-opfor.md)
->
-> **Iteration Guidance:** This is the mission command version — squad tasks state outcomes without prescribing specific positioning or movement. For earlier iterations with scaffolding, use [014-deliberate-attack-detailed.md](014-deliberate-attack-detailed.md). For a classroom walkthrough of the TLP steps applied to this OPORD, see [014 Walkthrough](014-deliberate-attack-walkthrough.md).
 
 **Time Zone Used Throughout the Plan/Order:** EASTERN STANDARD TIME
 
@@ -40,13 +39,13 @@ Platoon Sergeant
 ## 1. SITUATION
 
 ### a. Area of Interest
-The Camp Blanding LTA, Clay County, Florida. AO COTTO covers the southern LTA along the Bradenton Avenue and Arcadia Street corridors, with OBJ HERRERA at the Arcadia/Bradenton junction (MP 0600 1523), bounded north by the unnamed east-west road, east by Conex City, south by the LTA perimeter beyond Arcadia Street, and west by Clearwater Avenue (vicinity MP 0570 1515 to MP 0615 1540). The area of interest extends north along Bradenton Avenue past the unnamed east-west road, where REAPER reinforcements would stage, and south of Arcadia Street into the broader training area — the likely REAPER withdrawal corridor.
+AO COTTO covers the southern Camp Blanding LTA along the Bradenton Ave and Arcadia St corridors, with OBJ HERRERA at the Arcadia/Bradenton junction (MP 0600 1523) (vic MP 0570 1515 to MP 0615 1540). Area of interest extends north along Bradenton Ave past the unnamed E-W road (REAPER reinforcement staging) and south of Arcadia St into the broader training area (likely REAPER withdrawal corridor).
 
 ### b. Area of Operations
 
-**1. Terrain.** The Camp Blanding LTA is a road-bounded sector of the training area, roughly 1,200m east-west by 550m north-south, set in flat sandy-soil pine and hardwood forest. An improved road grid frames the LTA: Bradenton Avenue (N-S) runs through the center, Clearwater Avenue (N-S) bounds the west, Arcadia Street (E-W) bounds the south, and Jacksonville Street (E-W) bounds the north. Two unnamed roads — one N-S in the western LTA and one E-W through the interior — subdivide the woodlines. The FOB sits at MP 0610 1550 in the northeast; Conex City sits at MP 0611 1530 in the southeast. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire and the primary mounted avenues of approach. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to the roads, particularly after rain.
+**1. Terrain.** The Camp Blanding LTA is a road-bounded ~1,200m × 550m sector of flat sandy-soil pine and hardwood forest. Improved road grid: Bradenton Ave (N-S, center), Clearwater Ave (N-S, west), Arcadia St (E-W, south), Jacksonville St (E-W, north); two unnamed roads (one N-S in the western LTA, one E-W through the interior) subdivide the woodlines. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to roads. See [LTA Grid Reference](../reference/lta-grid-reference.md) for full terrain notes.
 
-   - **Key Terrain:** The road junction of Arcadia Street and Bradenton Avenue at OBJ HERRERA (MP 0600 1523) controls north-south and east-west movement through AO COTTO. The woodlines surrounding the junction on all sides provide covered and concealed avenues of approach for dismounted elements. Bradenton Avenue south of the junction provides a cleared lane of fire into the objective from the south.
+   - **Key Terrain:** Arcadia St / Bradenton Ave junction at OBJ HERRERA (MP 0600 1523) controls N-S and E-W movement through AO COTTO. Woodlines surrounding the junction provide covered/concealed dismounted approaches. Bradenton Ave south of the junction provides a cleared lane of fire into the objective from the south.
 
 **2. Weather.**
    - Skies: ________

--- a/STX/015-patrol-base-operations-company.md
+++ b/STX/015-patrol-base-operations-company.md
@@ -8,29 +8,22 @@
 >
 > **Complexity:** Higher | **Recommended Phase:** RUN (Night Iterations - Coaching Focus)
 >
-> **Mission Summary:** A Company is tasked to establish and occupy a patrol base in AO COTTO to conduct continuous operations, provide area security, and enable sustainment for follow-on missions. Three platoons execute distinct tasks: patrol base defense, forward screening, and company reserve.
+> **Training Focus:** Emphasizes company-level synchronization, echeloning security across multiple platoons, employment of a reserve, and coordination between elements with different missions. Candidates playing CO must manage fire support coordination between the screen and the patrol base, screen withdrawal procedures, and QRF employment criteria. Ideal for night iterations or planning-only TLP practice. Assign one evaluator per platoon.
 >
-> **Destination:** Patrol Base (PB) THUNDER, vicinity MP 0580 1520, AO COTTO, NLT ____.
->
-> **Actions on Objective:** Company conducts a leader's reconnaissance, occupies the patrol base with a deliberate occupation technique, establishes a screening element forward of the base on likely avenues of approach, and maintains a reserve / QRF within the perimeter. The company executes patrol base activities including security patrols, maintenance, and planning for follow-on operations.
->
-> **Training Focus:** This OPORD emphasizes company-level synchronization, echeloning security across multiple platoons, employment of a reserve, and coordination between elements with different missions. Candidates playing CO must manage fire support coordination between the screen and the patrol base, screen withdrawal procedures, and QRF employment criteria. Ideal for night training iterations or as a planning-only exercise for TLP practice.
->
-> **Evaluation Timeline:** For evaluated iterations, candidates will receive this OPORD and have 75 minutes to complete TLP Steps 1-8 before SP. Execution window is 60 minutes. AAR is 15 minutes.
+> **Evaluation Timeline:** 75 min for TLP Steps 1-8 before SP. 60 min execution window. 15 min AAR.
 >
 > **OPFOR/Training Wrinkles:**
-> - Probe the screen line first to test whether early warning reaches the patrol base and the CO reacts appropriately.
-> - Test QRF employment: simulate a penetration requiring 3rd Platoon to reinforce or counterattack.
-> - Simulate compromise of an OP requiring 2nd Platoon to displace or 3rd Platoon to react.
-> - Introduce an intelligence update requiring the CO to adjust platoon boundaries or reposition the screen.
-> - Test ability to coordinate 2nd Platoon's withdrawal through 1st Platoon's positions under pressure.
-> - Introduce resupply, casualty evacuation, or personnel issues during occupation.
+> - Probe the screen line first to test early warning to the patrol base and CO reaction.
+> - QRF employment: penetration requiring 3rd Platoon to reinforce or counterattack.
+> - OP compromise requiring 2nd Platoon to displace or 3rd Platoon to react.
+> - Intelligence update requiring the CO to adjust platoon boundaries or reposition the screen.
+> - 2nd Platoon's withdrawal through 1st Platoon's positions under pressure.
+> - Resupply, casualty evacuation, or personnel issues during occupation.
+> - UAS/Counter-UAS injects are OPTIONAL and only if authorized by the Commandant and in the approved POI.
 >
-> **NOTE:** UAS/Counter-UAS injects are OPTIONAL and should only be used if authorized by the Commandant and incorporated into the approved POI.
+> **Iteration Guidance:** Mission command version — platoon tasks state outcomes without prescribing layout or positioning. Squad leaders within each platoon develop their own schemes of maneuver.
 >
 > **See Also:** [LTA Grid Reference](../reference/lta-grid-reference.md) | [Patrol Base Operations (Platoon)](008-patrol-base-operations.md)
->
-> **Iteration Guidance:** This is the mission command version — platoon tasks state outcomes without prescribing specific positioning or movement. Squad leaders within each platoon develop their own schemes of maneuver.
 
 **Time Zone Used Throughout the Plan/Order:** EASTERN STANDARD TIME
 
@@ -49,13 +42,13 @@ First Sergeant (1SG)
 ## 1. SITUATION
 
 ### a. Area of Interest
-The Camp Blanding LTA, Clay County, Florida. AO COTTO covers the southwestern LTA — PB THUNDER (MP 0580 1520) and the surrounding company screen line, bounded north by the unnamed east-west road, east by Bradenton Avenue, south by the LTA perimeter beyond Arcadia Street, and west by Clearwater Avenue (vicinity MP 0570 1515 to MP 0605 1545). The area of interest extends north toward the FOB at MP 0610 1550, east across Bradenton Avenue into the central LTA, and south of Arcadia Street into the broader Camp Blanding training area — the corridors REAPER patrols could use to compromise the patrol base or push past the company screen.
+AO COTTO covers the southwestern Camp Blanding LTA — PB THUNDER (MP 0580 1520) and the surrounding company screen line (vic MP 0570 1515 to MP 0605 1545). Area of interest extends north toward the FOB at MP 0610 1550, east across Bradenton Ave into the central LTA, and south of Arcadia St into the broader training area — the corridors REAPER patrols could use to compromise the patrol base or push past the company screen.
 
 ### b. Area of Operations
 
-**1. Terrain.** The Camp Blanding LTA is a road-bounded sector of the training area, roughly 1,200m east-west by 550m north-south, set in flat sandy-soil pine and hardwood forest. An improved road grid frames the LTA: Bradenton Avenue (N-S) runs through the center, Clearwater Avenue (N-S) bounds the west, Arcadia Street (E-W) bounds the south, and Jacksonville Street (E-W) bounds the north. Two unnamed roads — one N-S in the western LTA and one E-W through the interior — subdivide the woodlines. The FOB sits at MP 0610 1550 in the northeast; Conex City sits at MP 0611 1530 in the southeast. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire and the primary mounted avenues of approach. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to the roads, particularly after rain. The unnamed east-west road and Bradenton Avenue frame the northern and eastern company screen sectors.
+**1. Terrain.** The Camp Blanding LTA is a road-bounded ~1,200m × 550m sector of flat sandy-soil pine and hardwood forest. Improved road grid: Bradenton Ave (N-S, center), Clearwater Ave (N-S, west), Arcadia St (E-W, south), Jacksonville St (E-W, north); two unnamed roads (one N-S in the western LTA, one E-W through the interior) subdivide the woodlines. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to roads. The unnamed E-W road and Bradenton Ave frame the northern and eastern company screen sectors. See [LTA Grid Reference](../reference/lta-grid-reference.md) for full terrain notes.
 
-   - **Key Terrain:** The planned patrol base site at MP 0580 1520 offers good concealment, defensible terrain, and access to covered withdrawal routes. The surrounding woodlines provide observation points for early warning. A small creek to the south provides a water source but may also canalize enemy approach. Elevated ground to the north offers observation of likely enemy avenues of approach and is suitable for screening element observation posts. Trail junctions on the northern and eastern avenues of approach provide natural positions for screening operations.
+   - **Key Terrain:** Planned patrol base site at MP 0580 1520 (concealment, defensible terrain, covered withdrawal routes). Surrounding woodlines provide observation points for early warning. Small creek to the south is a water source but may canalize enemy approach. Elevated ground to the north offers observation of likely avenues of approach and is suitable for screening OPs. Trail junctions on the northern and eastern avenues of approach provide natural screening positions.
 
 **2. Weather.**
    - Skies: ________

--- a/STX/016-deliberate-attack.md
+++ b/STX/016-deliberate-attack.md
@@ -8,26 +8,21 @@
 >
 > **Complexity:** Moderate | **Recommended Phase:** RUN (Day Iterations)
 >
-> **Mission Summary:** 1st Platoon attacks to seize OBJ HERRERA to deny REAPER use of a key road junction and enable follow-on operations.
+> **Training Focus:** Evaluates **individual squad leader planning and decision-making** within a platoon deliberate attack. The PL issues the platoon OPORD; each SL conducts their own TLP for an SBF, assault, or security task. Assign one evaluator per squad.
 >
-> **Destination:** OBJ HERRERA at MP 0600 1523, AO COTTO.
->
-> **Actions on Objective:** Platoon will establish an ORP, conduct leader's reconnaissance, isolate and suppress the objective, assault and seize the road junction, consolidate, and report.
->
-> **Evaluation Timeline:** For evaluated iterations, candidates will receive this OPORD and have 75 minutes to complete TLP Steps 1-8 before SP. Execution window is 60 minutes. AAR is 15 minutes.
+> **Evaluation Timeline:** 75 min for TLP Steps 1-8 before SP. 60 min execution window. 15 min AAR.
 >
 > **OPFOR/Training Wrinkles:**
-> - REAPER OP along Bradenton Ave south of the junction detects the SBF element during occupation — tests candidate's reaction to early detection and ability to adapt the plan.
-> - Civilian foot traffic along Arcadia Street during actions on the objective — tests ROE discipline and fire control measures.
-> - REAPER counterattack from the north through the woodline after the assault begins — tests whether the candidate planned for the MDCOA and positioned the security element effectively.
-> - Fallen tree or wire obstacle across the primary assault route through the woodline — tests adaptability and ability to designate alternate routes under pressure.
-> - REAPER RPK shifts fires from the Bradenton Ave corridor to the assault element's avenue of approach from the west — tests the SBF element's ability to identify and suppress the support weapon.
+> - REAPER OP along Bradenton Ave south of the junction detects the SBF during occupation — tests reaction to early detection and plan adaptation.
+> - Civilian foot traffic along Arcadia St during actions on the objective — tests ROE discipline and fire control.
+> - REAPER counterattack from the north through the woodline after assault begins — tests whether the candidate planned for the MDCOA and positioned security effectively.
+> - Fallen tree or wire obstacle across the primary assault route — tests adaptability and alternate-route designation under pressure.
+> - REAPER RPK shifts fires from Bradenton Ave to the assault element's western avenue of approach — tests SBF's ability to identify and suppress the support weapon.
+> - UAS/Counter-UAS injects are OPTIONAL and only if authorized by the Commandant and in the approved POI.
 >
-> **NOTE:** UAS/Counter-UAS injects are OPTIONAL and should only be used if authorized by the Commandant and incorporated into the approved POI.
+> **Iteration Guidance:** Mission command version — squad tasks state outcomes without prescribing layout or positioning. For scaffolded iterations, use [016-deliberate-attack-detailed.md](016-deliberate-attack-detailed.md).
 >
 > **See Also:** [LTA Grid Reference](../reference/lta-grid-reference.md)
->
-> **Iteration Guidance:** This is the mission command version — squad tasks state outcomes without prescribing specific positioning or movement. For the first iteration with a new class or candidates who need additional scaffolding, use [016-deliberate-attack-detailed.md](016-deliberate-attack-detailed.md) instead.
 
 **Time Zone Used Throughout the Plan/Order:** EASTERN STANDARD TIME
 
@@ -45,13 +40,13 @@ Platoon Sergeant
 ## 1. SITUATION
 
 ### a. Area of Interest
-The Camp Blanding LTA, Clay County, Florida. AO COTTO covers the southern LTA along the Bradenton Avenue and Arcadia Street corridors, with OBJ HERRERA at the Arcadia/Bradenton junction (MP 0600 1523), bounded north by the unnamed east-west road, east by Conex City, south by the LTA perimeter beyond Arcadia Street, and west by Clearwater Avenue (vicinity MP 0570 1515 to MP 0615 1540). The area of interest extends north along Bradenton Avenue past the unnamed east-west road, where REAPER reinforcements would stage, and south of Arcadia Street into the broader training area — the likely REAPER withdrawal corridor.
+AO COTTO covers the southern Camp Blanding LTA along the Bradenton Ave and Arcadia St corridors, with OBJ HERRERA at the Arcadia/Bradenton junction (MP 0600 1523) (vic MP 0570 1515 to MP 0615 1540). Area of interest extends north along Bradenton Ave past the unnamed E-W road (REAPER reinforcement staging) and south of Arcadia St into the broader training area (likely REAPER withdrawal corridor).
 
 ### b. Area of Operations
 
-**1. Terrain.** The Camp Blanding LTA is a road-bounded sector of the training area, roughly 1,200m east-west by 550m north-south, set in flat sandy-soil pine and hardwood forest. An improved road grid frames the LTA: Bradenton Avenue (N-S) runs through the center, Clearwater Avenue (N-S) bounds the west, Arcadia Street (E-W) bounds the south, and Jacksonville Street (E-W) bounds the north. Two unnamed roads — one N-S in the western LTA and one E-W through the interior — subdivide the woodlines. The FOB sits at MP 0610 1550 in the northeast; Conex City sits at MP 0611 1530 in the southeast. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire and the primary mounted avenues of approach. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to the roads, particularly after rain.
+**1. Terrain.** The Camp Blanding LTA is a road-bounded ~1,200m × 550m sector of flat sandy-soil pine and hardwood forest. Improved road grid: Bradenton Ave (N-S, center), Clearwater Ave (N-S, west), Arcadia St (E-W, south), Jacksonville St (E-W, north); two unnamed roads (one N-S in the western LTA, one E-W through the interior) subdivide the woodlines. Dense pine canopy and palmetto understory limit observation to under 50m off the road corridors, so the road grid provides the only extended fields of fire. Sandy soil supports dismounted movement everywhere but restricts wheeled traffic to roads. See [LTA Grid Reference](../reference/lta-grid-reference.md) for full terrain notes.
 
-   - **Key Terrain:** The road junction of Arcadia Street and Bradenton Avenue at OBJ HERRERA (MP 0600 1523) controls north-south and east-west movement through AO COTTO. The woodlines surrounding the junction on all sides provide covered and concealed avenues of approach for dismounted elements. Bradenton Avenue south of the junction provides a cleared lane of fire into the objective from the south.
+   - **Key Terrain:** Arcadia St / Bradenton Ave junction at OBJ HERRERA (MP 0600 1523) controls N-S and E-W movement through AO COTTO. Woodlines surrounding the junction provide covered/concealed dismounted approaches. Bradenton Ave south of the junction provides a cleared lane of fire into the objective from the south.
 
 **2. Weather.**
    - Skies: ________


### PR DESCRIPTION
Prototype reduction targeting non-doctrinal verbosity. Cadre/OPFOR Notes
drops Mission Summary, Destinations, and Actions on Objective (each
restated content already in Para 2, Tasks, and Concept of Ops). Area
of Interest tightened to a 2-sentence bounding-box + feeder summary.
Terrain keeps required content (size, vegetation, visibility, road
grid, trafficability) and links the LTA Grid Reference for deeper
detail. No doctrinal sections removed; 5-paragraph skeleton, CCIR/EEFI
structure, and Task/Purpose pairs preserved.