### PR TITLE
Simplify STX base OPORD tasks and trim CCIR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,8 @@ For all other operation types (raids, ambushes, defense, recon, etc.), there is 
 
 This is the **single source** of squad-level detail in the OPORD body. Each squad gets:
 
-- **Header:** Squad designation, functional role, and operation type (e.g., "1st Squad (Assault Element — Decisive Operation)")
-- **TASK:** Outcome-focused instructions — what to accomplish and the squad's general area of responsibility. The OPORD body version omits specific positioning grids, directional movement, team-level assignments, and movement sequences. See "Tiered Task Detail" below for the detailed version that lives in Cadre Notes.
+- **Header:** Squad designation, functional role, decisive/shaping designation, and "Main Effort" tag where applicable (e.g., "2nd Squad (Assault — Decisive Operation)").
+- **TASK:** One sentence — outcome and general area, not how. Doctrinally implied steps do NOT belong here: occupy an ORP/SBF, shift/lift/cease fires on signal, assault through the objective, consolidate, reorganize, break contact, withdraw, conduct SSE, collect intelligence, signal "objective secured", report findings. Layout choices (linear/L-shaped ambush, near/far-side recon) are SL planning decisions, not TASK content.
 - **PURPOSE:** Why THIS SQUAD'S task matters to the platoon plan. Not a restatement of Commander's Intent. Test: "If this squad fails, what specifically breaks?"
 
 ### Tiered Task Detail
@@ -78,7 +78,13 @@ Each OPORD maintains two versions of the Tasks to Subordinate Units. Candidates 
 
 ### Coordinating Instructions
 
-Items that apply to two or more units: ROE, CCIR (PIR + FFIR), EEFI, reporting requirements, timelines.
+Items that apply to two or more units: ROE, CCIR (PIR + FFIR), EEFI, reporting requirements, timelines. Keep these tight — every line should drive a decision or constrain a choice. Do not restate SOP, restate the mission, or include "confirm what we are about to find out anyway".
+
+- **ROE:** 3-4 lines. Don't list "PID before engagement" and "engage only confirmed combatants" as two items — pick one.
+- **PIR:** 3-5 lines, each one decision-driving (enemy stronger than expected, civilians at the objective, obstacle blocking the approach, reinforcement from another sector). Not a recon checklist.
+- **FFIR:** 2-3 lines, each tied to a PL decision (loss of comms, casualty rendering an element ineffective, compromise of an element before execution).
+- **EEFI:** 3 items typically — what the enemy would gain operational advantage from knowing.
+- **Reporting:** One line listing the standard reports (SP/LD, In Position, SALUTE on contact, LACE on consolidation). Don't bullet-point each.
 
 **Doctrine note (current ADP/FM 6-0):** CCIR is the umbrella heading. PIR (enemy / terrain / weather / civil) and FFIR (friendly force — combat power, casualties, sustainment, comms) are sub-lists under CCIR. Do NOT list PIR and CCIR as parallel categories. EEFI is a separate category (what we do NOT want the enemy to learn), not nested under CCIR. Full cadre reference: `reference/ccir-pir-eefi-doctrine.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,10 +37,11 @@ Some missions also have a `-TRAINING-GUIDE.md` variant or `-cadre-notes.md` with
 Each OPORD maintains two versions of Tasks to Subordinate Units. Candidates cycle through the same OPORDs, so early iterations provide scaffolded detail and later iterations require squad leaders to develop their own schemes of maneuver.
 
 **OPORD body (Mission Command version — the base `.md` file):**
-- Squad designation, functional role, and operation type in header
-- TASK states the outcome and general area — what to accomplish, not how to position
-- Does NOT include: specific positioning grids, directional movement, team-level assignments, movement sequencing
-- PURPOSE is always complete
+- Squad designation, functional role, decisive/shaping designation, and "Main Effort" tag in header
+- TASK is one sentence — outcome and general area, not how to position
+- TASK does NOT include: specific positioning grids, directional movement, team-level assignments, movement sequencing, **or doctrinally implied steps** (occupy ORP/SBF, shift/cease fires on signal, assault through, consolidate, reorganize, break contact, withdraw, SSE, collect intelligence, signal "objective secured", report findings)
+- TASK does NOT prescribe layout (linear/L-shaped ambush, near/far-side recon, etc.) — that is an SL planning decision
+- PURPOSE is always complete and answers "if this squad fails, what specifically breaks?"
 
 **Detailed version (`-detailed.md`):**
 - Full version of each squad's TASK with: specific grids, directional movement, approach routes, team assignments, departure order

--- a/STX/001-ambush.md
+++ b/STX/001-ambush.md
@@ -114,55 +114,45 @@ Priority of fires to 2nd Squad. Mortar support is available through company on r
 
 **1. 1st Squad (Independent Ambush — Western Segment):**
 
-- **TASK:** Conduct a linear ambush at OBJ FLUNKER (MP 0600 1530) along Bradenton Ave. Destroy the REAPER patrol transiting the segment and break contact to an assembly area. Report enemy strength and disposition.
-- **PURPOSE:** Deny REAPER the use of Bradenton Ave as a resupply route through the western portion of AO COTTO.
+- **TASK:** Ambush the REAPER patrol vic OBJ FLUNKER (MP 0600 1530) along Bradenton Ave.
+- **PURPOSE:** Deny REAPER use of Bradenton Ave as a resupply route through western AO COTTO.
 
-**2. 2nd Squad (Independent Ambush — Northwestern Segment):**
+**2. 2nd Squad (Independent Ambush — Northwestern Segment) — Main Effort:**
 
-- **TASK:** Conduct a linear ambush at OBJ KLENDATHU (MP 0585 1559) along the unnamed N-S road in the western LTA. Destroy the REAPER patrol transiting the segment and break contact to an assembly area. Report enemy strength and disposition.
-- **PURPOSE:** Deny REAPER the use of the western movement corridor and disrupt courier traffic in the northwestern sector of AO COTTO.
+- **TASK:** Ambush the REAPER patrol vic OBJ KLENDATHU (MP 0585 1559) along the unnamed N-S road.
+- **PURPOSE:** Deny REAPER use of the western corridor and disrupt courier traffic in the northwestern sector.
 
 **3. 3rd Squad (Independent Ambush — Southwestern Segment):**
 
-- **TASK:** Conduct a linear ambush at OBJ TANGO (MP 0575 1538) at the Clearwater Ave / unnamed road intersection. Destroy the REAPER patrol transiting the intersection and break contact to an assembly area. Report enemy strength and disposition.
-- **PURPOSE:** Deny REAPER the use of the southwestern road junction and disrupt dismounted patrol movement in that portion of AO COTTO.
+- **TASK:** Ambush the REAPER patrol vic OBJ TANGO (MP 0575 1538) at the Clearwater Ave / unnamed road intersection.
+- **PURPOSE:** Deny REAPER use of the southwestern road junction and disrupt dismounted patrol movement in that sector.
 
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only valid military targets.
-   2. Use minimum force necessary to accomplish the mission.
+   1. PID required before engagement; engage only confirmed combatants.
+   2. Use minimum force necessary.
    3. Avoid civilian casualties and collateral damage.
-   4. Positively identify targets before firing.
 
 **2. Commander's Critical Information Requirements (CCIR):**
 
-*Priority Intelligence Requirements (PIR — enemy, terrain, weather, civil):*
-   1. Confirm REAPER patrol composition at each site.
-   2. Monitor for changes in REAPER routes or reinforcements.
-   3. Assess civilian presence at each site before execution; report civilians in or adjacent to any kill zone at time of execution.
-   4. Enemy force composition at any site exceeds squad capability (reinforced element or crew-served weapons).
-   5. REAPER forces massing against a single squad from multiple sites.
+*Priority Intelligence Requirements (PIR):*
+   1. Civilians in or adjacent to a kill zone at time of execution.
+   2. Enemy at any site exceeds squad capability (reinforced or crew-served weapons).
+   3. REAPER massing against a single squad from multiple sites.
 
-*Friendly Force Information Requirements (FFIR — our own force):*
-   1. Compromise or detection of a squad prior to initiation at any site.
-   2. Any friendly casualty that reduces a squad below minimum effective strength.
+*Friendly Force Information Requirements (FFIR):*
+   1. Compromise of a squad prior to initiation.
+   2. Friendly casualty reducing a squad below effective strength.
 
 **3. Essential Elements of Friendly Information (EEFI):**
    1. SP/LD times and locations
-   2. Friendly unit positions and boundaries
+   2. Ambush site locations
    3. Casualty status and combat strength
 
-**4. Reporting:**
-   - **Report to higher when SP'ing or crossing the line of departure.**
-   - **SALUTE Report:** Upon enemy visual confirmation.
-   - **In Position Report:** Upon occupying an ambush site or ORP.
-   - **LACE Report:** After ambush, within ______ minutes.
+**4. Reporting:** SP/LD, SALUTE on enemy contact, In Position at the ambush site, LACE within ____ minutes of execution.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at their assigned sites.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
+**5. Coordination Between Squads:** Squads operate independently; adjacent squads continue their own mission on contact unless the PL directs otherwise.
 
 **6.** This OPORD is effective immediately upon distribution.
 

--- a/STX/002-movement-to-contact.md
+++ b/STX/002-movement-to-contact.md
@@ -109,58 +109,48 @@ Priority of fires to 1st Squad. Mortar support is available through company on r
 
 ### d. Tasks to Subordinate Units
 
-**1. 1st Squad (Western Zone):**
+**1. 1st Squad (Western Zone) — Main Effort:**
 
-- **TASK:** Conduct a movement to contact in the western zone of AO FLUNKER toward OBJ BAINTON (MP 0600 1538). Locate and engage REAPER forces, secure the objective, and report enemy strength and disposition.
-- **PURPOSE:** Clear the western approaches to deny REAPER use of the Bradenton Ave corridor for reinforcement or withdrawal.
+- **TASK:** Movement to contact toward OBJ BAINTON (MP 0600 1538). Develop the situation on contact.
+- **PURPOSE:** Clear the Bradenton Ave corridor to deny REAPER reinforcement and withdrawal through the western AO.
 
 **2. 2nd Squad (Central Zone):**
 
-- **TASK:** Conduct a movement to contact in the central zone of AO FLUNKER toward OBJ HERRERA (MP 0612 1546). Locate and engage REAPER forces, secure the objective, and report enemy strength and disposition.
-- **PURPOSE:** Develop the situation at the road junction to enable the company commander to control the central avenue of approach for follow-on operations.
+- **TASK:** Movement to contact toward OBJ HERRERA (MP 0612 1546). Develop the situation on contact.
+- **PURPOSE:** Develop the enemy picture at the central road junction so the company can control that avenue of approach.
 
 **3. 3rd Squad (Eastern Zone):**
 
-- **TASK:** Conduct a movement to contact in the eastern zone of AO FLUNKER toward OBJ BARLOW (MP 0613 1532). Locate and engage REAPER forces, secure the objective, and report enemy strength and disposition.
-- **PURPOSE:** Clear the eastern sector to prevent REAPER from using the built-up area as a defensive strongpoint or staging area.
+- **TASK:** Movement to contact toward OBJ BARLOW (MP 0613 1532). Develop the situation on contact.
+- **PURPOSE:** Clear the eastern sector to deny REAPER use of the built-up area as a defensive strongpoint.
 
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants posing a threat.
+   1. PID required before engagement; engage only confirmed combatants posing a threat.
    2. Use graduated response appropriate to the threat.
-   3. Avoid civilian engagement and minimize collateral damage.
-   4. Report civilian casualties immediately.
+   3. Avoid civilian casualties and minimize collateral damage.
 
 **2. Commander's Critical Information Requirements (CCIR):**
 
-*Priority Intelligence Requirements (PIR — enemy, terrain, weather, civil):*
-   1. Confirm REAPER personnel and weapons in each zone.
-   2. Identify fortifications and defensive positions.
-   3. Monitor REAPER movement between zones.
-   4. Assess civilian presence in each zone.
-   5. Initial contact with REAPER forces in any zone — report size, activity, location, and weapons immediately.
-   6. REAPER forces massing against a single squad from multiple zones.
+*Priority Intelligence Requirements (PIR):*
+   1. Initial contact with REAPER in any zone — report SALUTE immediately.
+   2. Enemy at any zone exceeds squad capability (reinforced or crew-served weapons).
+   3. Civilians in a squad's zone preventing planned fires or maneuver.
+   4. REAPER massing against a single squad from multiple zones.
 
-*Friendly Force Information Requirements (FFIR — our own force):*
-   1. Loss of communication with any squad for more than 10 minutes during movement.
+*Friendly Force Information Requirements (FFIR):*
+   1. Loss of communication with any squad for more than 10 minutes.
    2. Friendly casualty rendering any squad combat ineffective.
 
 **3. Essential Elements of Friendly Information (EEFI):**
    1. SP/LD times and locations
-   2. Friendly unit positions and boundaries
+   2. Friendly unit positions and zone boundaries
    3. Casualty status and combat strength
 
-**4. Reporting:**
-   - **Report to higher when crossing the line of departure.**
-   - **SALUTE Report:** Upon contact with enemy or relevant activity.
-   - **Objective Report:** Upon securing squad objective — report status, enemy situation, and disposition.
-   - **LACE Report:** Upon reaching objective.
+**4. Reporting:** SP/LD, SALUTE on contact, LACE on consolidation at the objective.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently within their zones. Lateral coordination at zone boundaries is the responsibility of adjacent squad leaders.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
+**5. Coordination Between Squads:** Squads operate independently in their zones; adjacent squad leaders coordinate lateral boundaries. On contact, adjacent squads continue their own mission unless the PL directs otherwise.
 
 **6.** This OPORD is effective immediately upon distribution.
 

--- a/STX/003-raid-a-bunker.md
+++ b/STX/003-raid-a-bunker.md
@@ -111,57 +111,46 @@ Priority of fires to 3rd Squad. Mortar support is available through company on r
 
 **1. 1st Squad (Independent Raid — OBJ COTTO):**
 
-- **TASK:** Conduct a squad raid at OBJ COTTO (MP 0600 1538) to destroy the small REAPER OP / cache at the Bradenton Ave intersection. Eliminate REAPER personnel at the objective, collect materials of intelligence value, and consolidate. Report enemy strength and findings.
-- **PURPOSE:** Destroy REAPER presence at a key road intersection and deny REAPER the use of this position for observation or resupply.
+- **TASK:** Raid OBJ COTTO (MP 0600 1538) to destroy the REAPER OP / cache at the Bradenton Ave intersection.
+- **PURPOSE:** Deny REAPER use of a key road intersection for observation and resupply.
 
 **2. 2nd Squad (Independent Raid — OBJ WHISKEY):**
 
-- **TASK:** Conduct a squad raid at OBJ WHISKEY (MP 0613 1532) to destroy the small REAPER commo relay / cache in the Conex City NE building. Eliminate REAPER personnel at the objective, collect materials of intelligence value, and consolidate. Report enemy strength and findings.
-- **PURPOSE:** Destroy REAPER communications node in Conex City and degrade REAPER's ability to coordinate across the AO.
+- **TASK:** Raid OBJ WHISKEY (MP 0613 1532) to destroy the REAPER commo relay / cache in the Conex City NE building.
+- **PURPOSE:** Degrade REAPER's ability to coordinate across the AO.
 
-**3. 3rd Squad (Independent Raid — OBJ ZULU):**
+**3. 3rd Squad (Independent Raid — OBJ ZULU) — Main Effort:**
 
-- **TASK:** Conduct a squad raid at OBJ ZULU (MP 0575 1524) to destroy the small REAPER OP at the Arcadia Street / Clearwater Avenue intersection. Eliminate REAPER personnel at the objective, collect materials of intelligence value, and consolidate. Report enemy strength and findings.
-- **PURPOSE:** Destroy REAPER observation capability in the southwestern AO and deny REAPER early warning of friendly movement into the sector.
+- **TASK:** Raid OBJ ZULU (MP 0575 1524) to destroy the REAPER OP at the Arcadia / Clearwater intersection.
+- **PURPOSE:** Deny REAPER early warning of friendly movement into the southwestern AO.
 
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants.
+   1. PID required before engagement; engage only confirmed combatants.
    2. Use graduated response appropriate to the threat.
    3. Avoid civilian harm and minimize collateral damage.
-   4. Report civilian casualties immediately.
 
 **2. Commander's Critical Information Requirements (CCIR):**
 
-*Priority Intelligence Requirements (PIR — enemy, terrain, weather, civil):*
-   1. Confirm REAPER personnel count and weapons at each node.
-   2. Identify any crew-served weapons, obstacles, or prepared positions at any objective.
-   3. Collect materials of intelligence value (documents, maps, radios, notebooks) from any objective.
-   4. Assess civilian presence at each objective; report civilians at or near an objective preventing planned fires.
-   5. Enemy strength at any objective exceeds expected composition (reinforced or crew-served weapons present).
-   6. Obstacle or IED on approach routes preventing timely assault.
-   7. REAPER forces massing against a single squad from multiple objectives.
+*Priority Intelligence Requirements (PIR):*
+   1. Civilians at or near an objective preventing planned fires.
+   2. Enemy at an objective exceeds expected composition (reinforced or crew-served weapons).
+   3. Obstacle or IED on an approach route preventing timely assault.
+   4. REAPER massing against a single squad from multiple objectives.
 
-*Friendly Force Information Requirements (FFIR — our own force):*
+*Friendly Force Information Requirements (FFIR):*
    1. Compromise of an assault force prior to actions on the objective.
-   2. Any friendly casualty during an assault requiring immediate MEDEVAC.
+   2. Casualty during an assault requiring immediate MEDEVAC.
 
 **3. Essential Elements of Friendly Information (EEFI):**
    1. SP/LD times and locations
-   2. Friendly unit positions and boundaries
+   2. ORP and objective locations
    3. Casualty status and combat strength
 
-**4. Reporting:**
-   - **Report to higher when SP'ing or crossing the line of departure.**
-   - **In Position Report:** Upon occupying an ORP or objective.
-   - **LACE Report:** At least once during operation and upon consolidation.
-   - **SALUTE Report:** Upon sighting enemy forces or indicators.
+**4. Reporting:** SP/LD, In Position at the ORP/objective, SALUTE on contact, LACE on consolidation. Submit any captured-materials report through the PL after consolidation.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at their assigned objectives.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
+**5. Coordination Between Squads:** Squads operate independently at their objectives; adjacent squads continue their own mission on contact unless the PL directs otherwise.
 
 **6.** This OPORD is effective immediately upon distribution.
 

--- a/STX/004-clear-dismount-city.md
+++ b/STX/004-clear-dismount-city.md
@@ -110,52 +110,44 @@ None.
 
 **1. 1st Squad (Assault — Decisive Operation):**
 
-- **TASK:** Clear and secure buildings along the main axis of advance through OBJ FLUNKER. Neutralize REAPER combatants in each structure. Report sectors clear by phase line. Upon consolidation, establish defensive positions in the central plaza area.
-- **PURPOSE:** Systematically eliminate REAPER's foothold in the urban area so the platoon can occupy and hold OBJ FLUNKER.
+- **TASK:** Clear REAPER from OBJ FLUNKER along the main axis of advance, reporting sectors clear by phase line.
+- **PURPOSE:** Eliminate REAPER's foothold in the urban area so the platoon can occupy and hold OBJ FLUNKER.
 
 **2. 2nd Squad (Support — Shaping Operation):**
 
-- **TASK:** Provide overwatch and suppressive fire as 1st Squad advances. Shift positions forward as phase lines are cleared. Be prepared to reinforce 1st Squad's clearing effort on order. During consolidation, establish defensive positions covering the assigned sector.
-- **PURPOSE:** Suppress REAPER fighters in depth so 1st Squad can close on and clear buildings without receiving flanking fire.
+- **TASK:** Suppress REAPER positions in depth in support of 1st Squad's clearance.
+- **PURPOSE:** Prevent flanking fire on 1st Squad as they close on and clear buildings.
 
 **3. 3rd Squad (Security — Shaping Operation):**
 
-- **TASK:** Secure the flanks and rear of the clearing operation. Block likely REAPER withdrawal and reinforcement routes. Maintain security of cleared sectors as the platoon advances. Monitor for civilian movement and report. During consolidation, establish defensive positions covering the assigned sector.
+- **TASK:** Block REAPER withdrawal and reinforcement and secure cleared sectors as the platoon advances.
 - **PURPOSE:** Prevent REAPER from escaping, reinforcing, or re-infiltrating cleared sectors behind the assault element.
 
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants.
-   2. Use minimum force necessary to accomplish the mission.
+   1. PID required before engagement; engage only confirmed combatants.
+   2. Use minimum force necessary.
    3. Avoid civilian casualties and minimize collateral damage.
-   4. Positively identify targets before firing.
-   5. Report civilian casualties immediately.
 
 **2. Commander's Critical Information Requirements (CCIR):**
 
-*Priority Intelligence Requirements (PIR — enemy, terrain, weather, civil):*
-   1. Identify REAPER positions, barricades, and IEDs.
-   2. Monitor for REAPER reinforcements or withdrawal attempts.
-   3. Assess civilian presence and movement in the city; report civilian concentration preventing use of planned fires or maneuver in a sector.
-   4. Identify underground routes or escape tunnels.
-   5. REAPER reinforcements entering the city from outside the cleared area during operations.
-   6. Discovery of NBC materials or indicators in any structure.
+*Priority Intelligence Requirements (PIR):*
+   1. Civilian concentration in a sector preventing planned fires or maneuver.
+   2. IEDs, barricades, or prepared positions on the axis of advance.
+   3. REAPER reinforcements entering the city from outside the cleared area.
+   4. Discovery of NBC materials, hostages, or underground routes in any structure.
 
-*Friendly Force Information Requirements (FFIR — our own force):*
-   1. Loss of communication between clearing teams during operations.
-   2. Friendly casualty rendering a clearing team combat ineffective.
+*Friendly Force Information Requirements (FFIR):*
+   1. Loss of communication between clearing teams.
+   2. Casualty rendering a clearing team combat ineffective.
 
 **3. Essential Elements of Friendly Information (EEFI):**
    1. SP/LD times and locations
-   2. Friendly unit positions and boundaries
+   2. Phase lines and unit positions
    3. Casualty status and combat strength
 
-**4. Reporting:**
-   - **Report to higher when SP'ing or crossing the line of departure.**
-   - **In Position Report:** Upon occupying the ORP or objective.
-   - **LACE Report:** At least once during operation and upon consolidation.
-   - **SALUTE Report:** Upon sighting enemy forces or indicators.
+**4. Reporting:** SP/LD, In Position at the ORP/objective, SALUTE on contact, sector-clear at each phase line, LACE on consolidation.
 
 **5.** This OPORD is effective immediately upon distribution.
 

--- a/STX/005-area-zone-reconnaissance.md
+++ b/STX/005-area-zone-reconnaissance.md
@@ -111,53 +111,43 @@ Fires are limited to self-defense only. Avoid engagement unless necessary to bre
 
 **1. 1st Squad (Reconnaissance — Northern Sector):**
 
-- **TASK:** Conduct reconnaissance of the northern sector of AO COTTO. Locate REAPER positions, assess activity, and identify defensive preparations, obstacles, and key terrain. Use covered and concealed routes, maintain noise and light discipline, and avoid detection. Report findings via SALUTE format. Return to ORP upon completion or if compromised.
+- **TASK:** Reconnoiter the northern sector of AO COTTO. Locate REAPER positions and assess strength, defensive preparations, and key terrain without compromise.
 - **PURPOSE:** Confirm or deny REAPER presence in the northern sector so the company can plan follow-on operations against a known enemy picture.
 
-**2. 2nd Squad (Reconnaissance — Southern Sector):**
+**2. 2nd Squad (Reconnaissance — Southern Sector) — Main Effort:**
 
-- **TASK:** Conduct reconnaissance of the southern sector of AO COTTO, including the suspected REAPER position. Locate REAPER positions, assess activity, and identify defensive preparations, obstacles, and key terrain. Use covered and concealed routes, maintain noise and light discipline, and avoid detection. Report findings via SALUTE format. Return to ORP upon completion or if compromised.
+- **TASK:** Reconnoiter the southern sector of AO COTTO, including the suspected REAPER position vic MP 0613 1532. Locate REAPER positions and assess strength, defensive preparations, and key terrain without compromise.
 - **PURPOSE:** Develop the intelligence picture in the sector most likely to contain REAPER's main position, enabling the company to identify objectives for follow-on operations.
 
 **3. 3rd Squad (ORP Security / QRF):**
 
-- **TASK:** Establish and secure the ORP. Maintain 360-degree security during reconnaissance operations. Monitor radio traffic from reconnaissance elements. Be prepared to move to support a compromised squad or provide suppressive fire to enable extraction. Account for all personnel upon return.
-- **PURPOSE:** Ensure the reconnaissance elements have a secure base to return to and a responsive QRF if compromised, preventing a tactical emergency from becoming a decisive engagement.
+- **TASK:** Secure the ORP and stand by as QRF for a compromised reconnaissance element.
+- **PURPOSE:** Provide a secure base and responsive QRF so a compromise does not become a decisive engagement.
 
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Avoid engagement unless necessary for self-defense or to break contact.
+   1. Engage only for self-defense or to break contact.
    2. Do not compromise the reconnaissance mission unless absolutely necessary.
    3. Avoid civilian contact and minimize detection.
-   4. Report enemy contact immediately but maintain mission focus on intelligence collection.
 
 **2. Commander's Critical Information Requirements (CCIR):**
 
-*Priority Intelligence Requirements (PIR — enemy, terrain, weather, civil):*
-   1. Confirm exact location of REAPER positions.
-   2. Assess REAPER strength, composition, and equipment.
-   3. Identify REAPER defensive positions, obstacles, and security measures.
-   4. Assess terrain features that affect friendly or REAPER operations.
-   5. Monitor for REAPER patrols or movement.
-   6. Enemy force size or disposition significantly different from the intelligence estimate.
-   7. Discovery of prepared defensive positions, obstacles, or IEDs on likely avenues of approach.
+*Priority Intelligence Requirements (PIR):*
+   1. REAPER strength, composition, or disposition significantly different from the intelligence estimate.
+   2. Prepared defensive positions, obstacles, or IEDs on likely avenues of approach.
+   3. Civilian presence in or adjacent to a suspected REAPER position.
 
-*Friendly Force Information Requirements (FFIR — our own force):*
+*Friendly Force Information Requirements (FFIR):*
    1. Compromise of any reconnaissance element.
    2. Loss of communication with any reconnaissance element.
 
 **3. Essential Elements of Friendly Information (EEFI):**
    1. SP/LD times and locations
-   2. Friendly unit positions and boundaries
-   3. Reconnaissance objectives and NAIs
+   2. ORP location and reconnaissance routes
+   3. NAIs and reconnaissance objectives
 
-**4. Reporting:**
-   - **Report to higher when SP'ing or crossing the line of departure.**
-   - **In Position Report:** Upon occupying the ORP.
-   - **SALUTE Report:** Upon sighting enemy forces or indicators.
-   - **Intelligence Report:** Upon completion of reconnaissance or at designated times.
-   - **LACE Report:** At end of reconnaissance phase or upon return to ORP.
+**4. Reporting:** SP/LD, In Position at the ORP, SALUTE on enemy sighting, Intel report on completion of reconnaissance, LACE on return to ORP.
 
 **5.** This OPORD is effective immediately upon distribution.
 

--- a/STX/008-patrol-base-operations.md
+++ b/STX/008-patrol-base-operations.md
@@ -111,58 +111,47 @@ Defensive fires planned for likely REAPER avenues of approach. Each squad respon
 
 ### d. Tasks to Subordinate Units
 
-**1. 1st Squad (Northern Sector):**
+**1. 1st Squad (Northern Sector) — Main Effort:**
 
-- **TASK:** Occupy and defend the northern sector of PB THUNDER. Establish fighting positions with interlocking fields of fire covering the northern avenues of approach. Provide personnel for LP/OP duty on the elevated ground to the north. Conduct local security patrols as directed. Execute priorities of work within the sector.
-- **PURPOSE:** Secure the most likely avenue of REAPER approach and provide the earliest warning of enemy reconnaissance or assault, giving the platoon time to react.
+- **TASK:** Occupy and defend the northern sector of PB THUNDER, oriented on the elevated ground to the north.
+- **PURPOSE:** Secure the most likely REAPER avenue of approach and provide earliest warning of enemy reconnaissance or assault.
 
 **2. 2nd Squad (Southeastern Sector):**
 
-- **TASK:** Occupy and defend the southeastern sector of PB THUNDER. Establish fighting positions with interlocking fields of fire covering the creek line approach and southeastern avenues. Provide personnel for LP/OP duty oriented toward the creek line. Execute priorities of work within the sector.
-- **PURPOSE:** Deny REAPER use of the creek line as a covered avenue of approach into the patrol base, preventing infiltration from the south and east.
+- **TASK:** Occupy and defend the southeastern sector of PB THUNDER, oriented on the creek line.
+- **PURPOSE:** Deny REAPER use of the creek line as a covered avenue of approach into the patrol base.
 
 **3. 3rd Squad (Southwestern Sector / QRF):**
 
-- **TASK:** Occupy and defend the southwestern sector of PB THUNDER. Establish fighting positions with interlocking fields of fire covering the southwestern avenues of approach. Serve as the platoon QRF, prepared to reinforce any sector under attack or establish a blocking position on a compromised avenue of approach to contain the REAPER penetration and enable the affected sector to reorganize. Rehearse reinforcement routes and blocking positions for 1st and 2nd Squad sectors. Identify and brief withdrawal routes for the platoon.
-- **PURPOSE:** Secure the southwestern perimeter and provide the PL a responsive reserve, ensuring any REAPER probe or assault can be met with concentrated force — either reinforcing the threatened sector or blocking the enemy avenue of approach.
+- **TASK:** Occupy and defend the southwestern sector of PB THUNDER and act as platoon QRF. Rehearse reinforcement to 1st and 2nd Squad sectors.
+- **PURPOSE:** Secure the southwestern perimeter and give the PL a responsive reserve to mass against any REAPER probe or assault.
 
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants posing a threat.
+   1. Engage only confirmed combatants posing a threat.
    2. Use graduated response appropriate to the threat.
-   3. Challenge unknown personnel using challenge and password.
-   4. Report all contacts immediately.
+   3. Challenge all unknown personnel.
 
 **2. Commander's Critical Information Requirements (CCIR):**
 
-*Priority Intelligence Requirements (PIR — enemy, terrain, weather, civil):*
-   1. REAPER probing, reconnaissance, or direct contact on any sector of the patrol base.
-   2. Indicators that the patrol base location has been observed or compromised by enemy or civilians.
+*Priority Intelligence Requirements (PIR):*
+   1. REAPER probing, reconnaissance, or direct contact on any sector.
+   2. Indicators the patrol base has been observed by enemy or civilians.
 
-*Friendly Force Information Requirements (FFIR — our own force):*
+*Friendly Force Information Requirements (FFIR):*
    1. Compromise or suspected compromise of the patrol base location.
    2. Loss of communication with any LP/OP.
-   3. Friendly casualty or equipment failure degrading any sector's security.
-   4. Water resupply point inaccessible or contaminated.
+   3. Casualty or equipment failure degrading any sector's security.
 
 **3. Essential Elements of Friendly Information (EEFI):**
    1. Patrol base grid location and limits
    2. LP/OP positions and crew-served weapon orientations
    3. Stand-to schedule and departure/return windows
-   4. Casualty status and combat strength
 
-**4. Reporting:**
-   - **Report to higher when departing current location.**
-   - **In Position Report:** Upon completing patrol base occupation.
-   - **SALUTE Report:** Upon sighting enemy forces or indicators.
-   - **SITREP:** At designated times (every 4 hours minimum).
-   - **LACE Report:** Upon occupation and prior to displacement.
+**4. Reporting:** Departure, In Position on occupation, SALUTE on enemy contact, SITREP every 4 hours, LACE on occupation and prior to displacement.
 
-**5. Stand-To Procedures:**
-   - Stand-to conducted 30 minutes before BMNT and 30 minutes before EENT.
-   - 100% alert during stand-to; all personnel in fighting positions.
-   - Stand-down only after PL or PSG conducts assessment and issues order.
+**5. Stand-To Procedures:** 30 minutes before BMNT and EENT; 100% alert in fighting positions; stand-down only on PL or PSG order.
 
 **6.** This OPORD is effective immediately upon distribution.
 

--- a/STX/009-tactical-road-march.md
+++ b/STX/009-tactical-road-march.md
@@ -120,51 +120,43 @@ No planned fires. 1st Squad, as the lead element, has priority of indirect fires
 
 **1. 1st Squad (Lead / Point Security):**
 
-- **TASK:** Lead the march from the SP to RP THUNDER. Provide point security with a minimum two-man point team. Conduct route reconnaissance forward of the main body. Identify and report danger areas and obstacles. Halt and establish near-side security at each danger area before the main body crosses.
-- **PURPOSE:** Provide the platoon early warning and ensure the route is clear, so the main body can move without halting unexpectedly at an unsecured position.
+- **TASK:** Lead the march from SP to RP THUNDER. Reconnoiter forward of the main body and secure near-side of each danger area before the main body crosses.
+- **PURPOSE:** Give the platoon early warning and a cleared route so the main body moves without halting at unsecured ground.
 
 **2. 2nd Squad (Main Body):**
 
-- **TASK:** Move behind platoon headquarters in the order of march. Maintain visual contact with the lead and trail elements. Be prepared to reinforce point security at danger areas or rear security on contact. During security halts, provide local security of the main body's position.
-- **PURPOSE:** Maintain platoon cohesion and provide the PL immediately available combat power to reinforce whichever security element makes contact.
+- **TASK:** Move behind platoon headquarters; be prepared to reinforce point or trail on contact.
+- **PURPOSE:** Maintain platoon cohesion and give the PL immediately available combat power to mass on whichever security element makes contact.
 
 **3. 3rd Squad (Trail / Rear Security):**
 
-- **TASK:** Move as the trail element. Provide rear security throughout the march. Maintain accountability of all personnel and equipment — no one falls behind without report. Report any enemy activity, tracking, or stragglers immediately. Upon arrival at RP THUNDER, confirm to PSG that all personnel have closed on the position.
-- **PURPOSE:** Prevent REAPER from trailing or flanking the formation from the rear, and ensure the platoon arrives at RP THUNDER at full strength.
+- **TASK:** Move as the trail element. Provide rear security and maintain accountability.
+- **PURPOSE:** Prevent REAPER from trailing or flanking from the rear and ensure the platoon arrives at full strength.
 
 ### f. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants posing a threat.
+   1. Engage only confirmed combatants posing a threat.
    2. Use graduated response appropriate to the threat.
    3. Avoid civilian contact and minimize detection.
-   4. Report all contacts immediately.
 
 **2. Commander's Critical Information Requirements (CCIR):**
 
-*Priority Intelligence Requirements (PIR — enemy, terrain, weather, civil):*
-   1. Identify REAPER observation posts or reconnaissance elements along the route.
-   2. Confirm route is clear of obstacles or IEDs; report obstacle or IED blocking the primary route of march.
-   3. Assess civilian presence along the route of march.
-   4. Monitor for changes in enemy activity or posture; report enemy contact that halts movement for more than 15 minutes.
-   5. Route conditions requiring deviation from the planned route.
+*Priority Intelligence Requirements (PIR):*
+   1. Obstacle, IED, or route condition forcing deviation from the planned route.
+   2. REAPER observation or contact along the route.
+   3. Civilian presence concentrated at a danger area or checkpoint.
 
-*Friendly Force Information Requirements (FFIR — our own force):*
-   1. Loss of contact with any element in the march order.
+*Friendly Force Information Requirements (FFIR):*
+   1. Loss of visual contact with any element in the march order.
+   2. Casualty or straggler requiring the platoon to halt.
 
 **3. Essential Elements of Friendly Information (EEFI):**
    1. SP time, route of march, and RP arrival window
    2. Order of march and intervals
    3. Casualty status and combat strength
 
-**4. Reporting:**
-   - **Report to higher when SP'ing from the assembly area.**
-   - **Checkpoint Reports:** Upon reaching each designated checkpoint.
-   - **Danger Area Reports:** Upon clearing each danger area.
-   - **In Position Report:** Upon arrival at RP THUNDER.
-   - **SALUTE Report:** Upon sighting enemy forces or indicators.
-   - **LACE Report:** Upon arrival at RP THUNDER.
+**4. Reporting:** SP, each CP, clearance of each danger area, SALUTE on enemy contact, In Position and LACE at RP THUNDER.
 
 **5. Route and Checkpoints:**
    - SP: Assembly Area (MP 0598 1538)

--- a/STX/010-dsca-convoy-operations.md
+++ b/STX/010-dsca-convoy-operations.md
@@ -129,18 +129,18 @@ Not applicable (DSCA operation).
 
 **1st Platoon (Convoy Element — Main Effort):**
 
-- **TASK:** Plan and execute the logistics convoy from Camp Blanding to Bay County Staging Area. PL leads in HMMWV, navigates the primary route, and makes rerouting decisions at obstacles. PSG trails in HMMWV, monitors convoy integrity, and manages recovery if a vehicle breaks down. Maintain accountability of all personnel and supplies throughout movement. Deliver supplies to the staging area and prepare for follow-on operations.
-- **PURPOSE:** Transport relief supplies along the 200-mile route so humanitarian assistance operations can begin in Bay County.
+- **TASK:** Conduct the logistics convoy from Camp Blanding to the Bay County Staging Area and deliver supplies.
+- **PURPOSE:** Move relief supplies along the 200-mile route so humanitarian assistance can begin in Bay County.
 
 **2nd Platoon:**
 
-- **TASK:** Maintain security of Camp Blanding assembly area and be prepared to dispatch recovery assets if required.
-- **PURPOSE:** Secure the rear area and provide support if the convoy requires recovery or resupply.
+- **TASK:** Secure the Camp Blanding assembly area; be prepared to dispatch recovery assets.
+- **PURPOSE:** Provide rear-area support if the convoy requires recovery or resupply.
 
 **3rd Platoon:**
 
-- **TASK:** Secure Bay County Staging Area, prepare to receive the convoy, and coordinate with county emergency management for supply transfer procedures.
-- **PURPOSE:** Ensure the delivery point is secure and ready so supplies can be offloaded and distributed without delay.
+- **TASK:** Secure the Bay County Staging Area and coordinate with county emergency management for supply transfer.
+- **PURPOSE:** Ensure the delivery point is ready so supplies can be offloaded and distributed without delay.
 
 ### f. Coordinating Instructions
 

--- a/STX/011-dsca-mounted-reconnaissance.md
+++ b/STX/011-dsca-mounted-reconnaissance.md
@@ -138,7 +138,7 @@ Not applicable (DSCA operation).
 
 **1st Platoon (Sectors 1 & 2 — Main Effort):**
 
-- **TASK:** Conduct mounted reconnaissance of Sector 1 (US-231 corridor from county line to Panama City) and Sector 2 (Panama City urban area including US-98 coastal segment). Assess route trafficability for LMTV convoys, document infrastructure damage, identify hazards (downed lines, flooding, structural collapse), and locate potential POD sites (minimum 3). Document all findings with photos/video and grid coordinates. Report immediately upon finding routes CLOSED, bridges DAMAGED, or immediate hazards. Consolidate at the staging area upon completion.
+- **TASK:** Reconnoiter Sector 1 (US-231 corridor) and Sector 2 (Panama City urban area, including US-98 coastal segment). Assess route trafficability for LMTV convoys, identify hazards, and locate POD sites (minimum 3).
 - **PURPOSE:** Provide the route assessment for the primary supply corridor so the battalion can determine whether convoys can reach Bay County and where to establish distribution points.
 
 **Priority Reconnaissance Objectives:**
@@ -151,12 +151,12 @@ Not applicable (DSCA operation).
 
 **2nd Platoon (Sectors 3 & 4):**
 
-- **TASK:** Conduct mounted reconnaissance of Sector 3 (SR-77 corridor) and Sector 4 (western Bay County). Assess alternate route trafficability, document damage, and identify potential POD sites.
+- **TASK:** Reconnoiter Sector 3 (SR-77 corridor) and Sector 4 (western Bay County). Assess alternate route trafficability and locate POD sites.
 - **PURPOSE:** Provide assessment of alternate routes in case the primary corridor is impassable.
 
 **3rd Platoon (Staging Area Security / QRF):**
 
-- **TASK:** Maintain security of Bay County Staging Area. Serve as Quick Reaction Force to support reconnaissance elements if required (vehicle recovery, medical emergency).
+- **TASK:** Secure the Bay County Staging Area and act as QRF for reconnaissance elements.
 - **PURPOSE:** Secure the staging area and provide emergency support so reconnaissance platoons can focus on their sectors.
 
 ### e. Coordinating Instructions

--- a/STX/012-dsca-point-of-distribution.md
+++ b/STX/012-dsca-point-of-distribution.md
@@ -135,7 +135,7 @@ Not applicable (DSCA operation).
 
 **1st Platoon (POD Site ALPHA — Main Effort):**
 
-- **TASK:** Establish and operate POD Site ALPHA at Panama City High School. Set up traffic flow with a single entry control point, minimum two distribution lanes, and a single exit to prevent return traffic. Distribute emergency supplies (water, ice, MREs, tarps) per household limits. Maintain supply accountability using tally sheets with hourly reports to Company TOC. Request resupply when at 25% remaining. Establish a walk-up area for civilians without vehicles. Transition or close POD on order.
+- **TASK:** Establish and operate POD Site ALPHA at Panama City High School. Distribute supplies per household limits and request resupply at 25% remaining.
 - **PURPOSE:** Serve the maximum number of affected households in the Panama City area while maintaining accountability and order.
 
 **Distribution Limits (per household):**
@@ -155,13 +155,13 @@ Not applicable (DSCA operation).
 
 **2nd Platoon (POD Site BRAVO):**
 
-- **TASK:** Establish and operate POD Site BRAVO at Lynn Haven Community Center using same procedures and distribution limits as POD Site ALPHA.
-- **PURPOSE:** Extend distribution coverage to the Lynn Haven area so the company serves both major population centers.
+- **TASK:** Establish and operate POD Site BRAVO at Lynn Haven Community Center using the same procedures and distribution limits.
+- **PURPOSE:** Extend distribution coverage to Lynn Haven so the company serves both major population centers.
 
 **3rd Platoon (Resupply / QRF):**
 
-- **TASK:** Conduct resupply runs from Bay County Staging Area to POD sites as requested. Serve as Quick Reaction Force to support POD operations (crowd control, medical emergency, vehicle recovery).
-- **PURPOSE:** Keep distribution lanes supplied so neither POD runs out, and provide emergency response so POD personnel can stay focused on distribution.
+- **TASK:** Conduct resupply runs from the Bay County Staging Area to POD sites and act as QRF.
+- **PURPOSE:** Keep distribution lanes supplied and provide emergency response so POD personnel can stay focused on distribution.
 
 ### e. Coordinating Instructions
 

--- a/STX/014-deliberate-attack.md
+++ b/STX/014-deliberate-attack.md
@@ -110,53 +110,44 @@ None.
 
 **1. 1st Squad (Support by Fire — Shaping Operation):**
 
-- **TASK:** Occupy a support-by-fire position with observation of OBJ HERRERA. On the PL's signal, initiate suppressive fire into REAPER positions at the junction. Shift or cease fires on order as 2nd Squad enters the objective.
-- **PURPOSE:** Fix REAPER in their fighting positions so 2nd Squad can close on and assault through the objective without receiving aimed fire from the south-facing positions.
+- **TASK:** Suppress REAPER positions on OBJ HERRERA from a support-by-fire position south of the junction.
+- **PURPOSE:** Fix REAPER so 2nd Squad can close on and assault through the objective without aimed fire from the south-facing positions.
 
 **2. 2nd Squad (Assault — Decisive Operation):**
 
-- **TASK:** Move to an assault position near OBJ HERRERA. On order, assault through the objective, clearing through REAPER positions at the junction. Destroy REAPER forces and seize the road junction. Signal "objective secured" upon completion.
-- **PURPOSE:** Destroy the enemy force on the objective and seize the key terrain that controls movement through AO COTTO.
+- **TASK:** Seize OBJ HERRERA and destroy the REAPER CP. Conduct hasty SSE of the CP site.
+- **PURPOSE:** Destroy enemy C2 in AO COTTO and seize the key terrain that controls movement through the AO.
 
 **3. 3rd Squad (Security / Reserve):**
 
-- **TASK:** Secure the ORP and provide rear security during the assault. On order, establish a blocking position along the northern avenue of approach to deny REAPER reinforcement from reaching the objective area. Be prepared to reinforce 1st or 2nd Squad on order.
-- **PURPOSE:** Provide the PL a reserve to exploit success or respond to REAPER counterattack, and deny REAPER reinforcement from the north while the assault element secures the CP.
+- **TASK:** Secure the ORP. On order, block the northern avenue of approach.
+- **PURPOSE:** Deny REAPER reinforcement from the north and give the PL a reserve to exploit success or respond to counterattack.
 
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants.
-   2. Use minimum force necessary to accomplish the mission.
+   1. PID required before engagement; engage only confirmed combatants.
+   2. Use minimum force necessary.
    3. Avoid civilian casualties and collateral damage.
-   4. Positively identify targets before firing.
 
 **2. Commander's Critical Information Requirements (CCIR):**
 
-*Priority Intelligence Requirements (PIR — enemy, terrain, weather, civil):*
-   1. Confirm REAPER CP location and security positions at OBJ HERRERA, specifically their orientation along Arcadia Street and Bradenton Avenue.
-   2. Identify REAPER CP infrastructure: antenna placement, number of vehicles, generator noise, or other indicators of CP activity.
-   3. Identify any REAPER reinforcement routes from the north through the woodline or along Bradenton Avenue.
-   4. Assess civilian presence in the area, particularly along Arcadia Street and in the vicinity of any structures near the objective.
-   5. Enemy strength or disposition at OBJ HERRERA significantly different from the intelligence estimate.
-   6. REAPER CP has displaced or been abandoned before the assault.
-   7. REAPER reinforcements approaching from the north along Bradenton Avenue or through the woodline.
-   8. REAPER CP staff observed destroying documents or equipment (indicates compromise — accelerate assault timeline).
+*Priority Intelligence Requirements (PIR):*
+   1. REAPER strength or disposition at OBJ HERRERA significantly different from the intelligence estimate.
+   2. REAPER CP staff observed destroying documents or equipment — compromise indicator; accelerate the assault.
+   3. REAPER reinforcements approaching from the north through the woodline or along Bradenton Ave.
+   4. Civilians on or adjacent to the objective preventing planned fires.
 
-*Friendly Force Information Requirements (FFIR — our own force):*
-   1. Loss of the support-by-fire position or inability to achieve fire superiority.
-   2. Friendly casualty in the assault element requiring immediate MEDEVAC.
+*Friendly Force Information Requirements (FFIR):*
+   1. Loss of the SBF position or inability to achieve fire superiority.
+   2. Casualty in the assault element requiring immediate MEDEVAC.
 
 **3. Essential Elements of Friendly Information (EEFI):**
    1. SP/LD times and locations
-   2. SBF and ORP positions
+   2. ORP and SBF positions
    3. Casualty status and combat strength
 
-**4. Reporting:**
-   - **Report to higher when SP'ing or crossing the line of departure.**
-   - **In Position Report:** Upon occupying the ORP and the SBF position.
-   - **SALUTE Report:** Upon visual confirmation of enemy.
-   - **LACE Report:** Upon seizure and consolidation on the objective.
+**4. Reporting:** SP/LD, In Position at the ORP and SBF, SALUTE on enemy contact, LACE on consolidation. Report SSE findings to higher as collected.
 
 **5.** This OPORD is effective immediately upon distribution.
 

--- a/STX/016-deliberate-attack.md
+++ b/STX/016-deliberate-attack.md
@@ -111,52 +111,44 @@ None.
 
 **1. 1st Squad (Support by Fire — Shaping Operation):**
 
-- **TASK:** Occupy a support-by-fire position with observation of OBJ HERRERA. On the PL's signal, initiate suppressive fire into REAPER positions at the junction. Suppress or destroy the REAPER support weapon. Shift or cease fires on order as 2nd Squad enters the objective.
-- **PURPOSE:** Fix REAPER in their fighting positions and neutralize the support weapon so 2nd Squad can close on and assault through the objective without receiving aimed fire.
+- **TASK:** Suppress REAPER on OBJ HERRERA from a support-by-fire position. Priority target: the RPK.
+- **PURPOSE:** Fix REAPER and neutralize the support weapon so 2nd Squad can close on and assault through the objective.
 
 **2. 2nd Squad (Assault — Decisive Operation):**
 
-- **TASK:** Move to an assault position near OBJ HERRERA. On order, assault through the objective, clearing through REAPER fighting positions at the junction. Destroy REAPER forces and seize the road junction. Signal "objective secured" upon completion.
+- **TASK:** Seize OBJ HERRERA and destroy REAPER forces at the junction.
 - **PURPOSE:** Destroy the enemy force on the objective and seize the key terrain that controls movement through AO COTTO.
 
 **3. 3rd Squad (Security — Shaping Operation):**
 
-- **TASK:** Isolate OBJ HERRERA prior to the assault. Block REAPER reinforcement and escape routes. Maintain positions through the assault. Collapse security last during platoon consolidation and move to the objective.
-- **PURPOSE:** Prevent REAPER reinforcement from the north so 2nd Squad fights only the force currently at the junction, and secure the platoon's withdrawal route.
+- **TASK:** Isolate OBJ HERRERA prior to the assault and block REAPER reinforcement and escape from the north.
+- **PURPOSE:** Ensure 2nd Squad fights only the force at the junction and secure the platoon's withdrawal route.
 
 ### e. Coordinating Instructions
 
 **1. Rules of Engagement (ROE):**
-   1. Engage only confirmed enemy combatants.
-   2. Use minimum force necessary to accomplish the mission.
+   1. PID required before engagement; engage only confirmed combatants.
+   2. Use minimum force necessary.
    3. Avoid civilian casualties and collateral damage.
-   4. Positively identify targets before firing.
 
 **2. Commander's Critical Information Requirements (CCIR):**
 
-*Priority Intelligence Requirements (PIR — enemy, terrain, weather, civil):*
-   1. Confirm REAPER positions and strength at OBJ HERRERA, specifically their orientation along Arcadia Street and Bradenton Avenue.
-   2. Locate and confirm the REAPER OP south of the junction along Bradenton Avenue.
-   3. Identify any REAPER reinforcement routes from the north through the woodline or along Clearwater Avenue.
-   4. Assess civilian presence in the area, particularly along Arcadia Street and in the vicinity of structures east of the objective; report civilians on or near the objective preventing planned fires.
-   5. Enemy strength or disposition at OBJ HERRERA significantly different from the intelligence estimate.
-   6. REAPER OP detected on approach route — early warning compromised or not neutralized.
-   7. REAPER reinforcements approaching from the north along Clearwater Avenue or through the woodline.
+*Priority Intelligence Requirements (PIR):*
+   1. REAPER strength or disposition at OBJ HERRERA significantly different from the intelligence estimate.
+   2. REAPER OP detected on the approach route — early warning compromised or not neutralized.
+   3. REAPER reinforcements approaching from the north along Clearwater Ave or through the woodline.
+   4. Civilians on or adjacent to the objective preventing planned fires.
 
-*Friendly Force Information Requirements (FFIR — our own force):*
-   1. Loss of the support-by-fire position or inability to achieve fire superiority over the RPK.
-   2. Friendly casualty in the assault element requiring immediate MEDEVAC.
+*Friendly Force Information Requirements (FFIR):*
+   1. Loss of the SBF position or inability to achieve fire superiority over the RPK.
+   2. Casualty in the assault element requiring immediate MEDEVAC.
 
 **3. Essential Elements of Friendly Information (EEFI):**
    1. SP/LD times and locations
-   2. Friendly unit positions and boundaries
+   2. ORP and SBF positions
    3. Casualty status and combat strength
 
-**4. Reporting:**
-   - **Report to higher when SP'ing or crossing the line of departure.**
-   - **In Position Report:** Upon occupying the ORP and the SBF position.
-   - **SALUTE Report:** Upon visual confirmation of enemy, including the OP.
-   - **LACE Report:** Upon seizure and consolidation on the objective.
+**4. Reporting:** SP/LD, In Position at the ORP and SBF, SALUTE on enemy contact (including the OP), LACE on consolidation.
 
 **5.** This OPORD is effective immediately upon distribution.
 

--- a/reference/opord-format-reference.md
+++ b/reference/opord-format-reference.md
@@ -110,9 +110,9 @@ e.  (U) Coordinating Instructions.
 **c. Scheme of Fires** — Priority of indirect fires (which subordinate unit gets first call on indirect fire assets), fire support assets available, and restrictions. Unique information only.
 
 **d. Tasks to Subordinate Units** — The ONE place with squad-specific detail.
-- **TASK:** The squad's outcome-focused instructions — what to accomplish, general area of responsibility, and key coordination (triggers, on-order actions). The OPORD body states tasks at a mission-command level, omitting specific positioning grids, directional movement, and team-level assignments. The detailed version with specific grids, routes, and team assignments lives in the Cadre Notes under "Detailed Squad Tasks (Early Iterations)" for use during initial training iterations.
+- **TASK:** One sentence stating the outcome and general area — what to accomplish, not how. Verbosity confuses candidates and undermines mission command. Doctrinally implied steps **do not** go in TASK: occupy an ORP, occupy an SBF, shift/lift/cease fires on signal, assault through the objective, consolidate, reorganize, break contact, withdraw to an assembly area, conduct SSE, collect intelligence, signal "objective secured", report findings. Layout terms (linear/L-shaped, near/far-side, etc.) also do not belong here — those are SL planning decisions. The detailed version with specific grids, routes, and team assignments lives in the `-detailed.md` companion file for scaffolded iterations.
 - **PURPOSE:** Why THIS SQUAD's task matters to the platoon plan specifically. Test: "If this squad fails, what specifically breaks?" Do not restate the Commander's Intent. A good purpose connects the squad's task to the next phase or another element's success. Identical between lean and detailed versions.
-- Include the element's role (Assault, Support, Security, Reserve) and whether it is the decisive or shaping operation in the header.
+- Include the element's role (Assault, Support, Security, Reserve), the decisive/shaping designation, and a "Main Effort" tag where applicable, in the header.
 
 **e. Coordinating Instructions** — Cross-cutting guidance that applies to two or more units. ROE, CCIR (PIR + FFIR), EEFI, reporting requirements, time hacks, restrictions.
 


### PR DESCRIPTION
Strip doctrinally implied steps (occupy ORP/SBF, shift fires on signal,
assault through, consolidate, break contact, SSE, "objective secured"
signal, report findings) from TASK statements in all base STX OPORDs.
Tasks now state outcome + general area in one sentence; squad leaders
develop the how during their own TLP. Layout terms (linear/L-shaped)
removed for the same reason.

Trim CCIR PIR to 3-5 decision-driving items per OPORD (drop "confirm
what we'll find out anyway" and vague monitoring requirements).
Collapse reporting bullet lists to single lines. Tighten ROE to
non-redundant items.

Update CLAUDE.md, AGENTS.md, and reference/opord-format-reference.md
to codify the convention so future iterations don't regress.

Detailed (`-detailed.md`) variants left unchanged — they remain the
scaffolded version for early candidate iterations per the tiered-task
convention.