### PR TITLE
Remove non-doctrinal "Coordination Between Squads" subsection

### DIFF
--- a/STX/001-ambush-detailed.md
+++ b/STX/001-ambush-detailed.md
@@ -170,12 +170,7 @@ Priority of fires to 2nd Squad. Mortar support is available through company on r
    - **In Position Report:** Upon occupying an ambush site or ORP.
    - **LACE Report:** After ambush, within ______ minutes.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at their assigned sites.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/001-ambush.md
+++ b/STX/001-ambush.md
@@ -152,9 +152,7 @@ Priority of fires to 2nd Squad. Mortar support is available through company on r
 
 **4. Reporting:** SP/LD, SALUTE on enemy contact, In Position at the ambush site, LACE within ____ minutes of execution.
 
-**5. Coordination Between Squads:** Squads operate independently; adjacent squads continue their own mission on contact unless the PL directs otherwise.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/001b-ambush-detailed.md
+++ b/STX/001b-ambush-detailed.md
@@ -172,12 +172,7 @@ Priority of fires to 2nd Squad. Mortar support is available through company on r
    - **Intelligence Report:** Upon SSE completion — report all materials found.
    - **LACE Report:** After ambush, within ______ minutes.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at their assigned sites.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/001c-ambush-detailed.md
+++ b/STX/001c-ambush-detailed.md
@@ -172,12 +172,7 @@ Priority of fires to 2nd Squad. Mortar support is available through company on r
    - **Intelligence Report:** Upon SSE completion — report all weapons and materials found.
    - **LACE Report:** After ambush, within ______ minutes.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at their assigned sites.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/001d-ambush-detailed.md
+++ b/STX/001d-ambush-detailed.md
@@ -172,12 +172,7 @@ Priority of fires to 2nd Squad. Mortar support is available through company on r
    - **Intelligence Report:** Upon SSE completion — report all survey materials and documents found.
    - **LACE Report:** After ambush, within ______ minutes.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at their assigned sites.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/002-movement-to-contact-detailed.md
+++ b/STX/002-movement-to-contact-detailed.md
@@ -182,12 +182,7 @@ Priority of fires to 1st Squad. Mortar support is available through company on r
    - **LOA reached** — report on the platoon net.
    - **LACE Report** — on consolidation.
 
-**6. Coordination Between Squads:**
-   - Squads operate independently within their zones. Lateral coordination at zone boundaries is the responsibility of adjacent squad leaders.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**7.** This OPORD is effective immediately upon distribution.
+**6.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/002-movement-to-contact.md
+++ b/STX/002-movement-to-contact.md
@@ -159,9 +159,7 @@ Priority of fires to 1st Squad. Mortar support is available through company on r
 
 **5. Reporting:** SP/LD crossing, SALUTE on contact, PL BLUE crossing, LOA reached, LACE on consolidation.
 
-**6. Coordination Between Squads:** Squads operate independently in their zones; adjacent squad leaders coordinate lateral boundaries. On contact, adjacent squads continue their own mission unless the PL directs otherwise.
-
-**7.** This OPORD is effective immediately upon distribution.
+**6.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/002b-movement-to-contact-detailed.md
+++ b/STX/002b-movement-to-contact-detailed.md
@@ -182,12 +182,7 @@ Priority of fires to 1st Squad. Mortar support is available through company on r
    - **LOA reached** — report on the platoon net.
    - **LACE Report** — on consolidation.
 
-**6. Coordination Between Squads:**
-   - Squads operate independently within their zones. Lateral coordination at zone boundaries is the responsibility of adjacent squad leaders.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**7.** This OPORD is effective immediately upon distribution.
+**6.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/002c-movement-to-contact-detailed.md
+++ b/STX/002c-movement-to-contact-detailed.md
@@ -181,12 +181,7 @@ Priority of fires to 1st Squad. Mortar support is available through company on r
    - **LOA reached** — report on the platoon net.
    - **LACE Report** — on consolidation.
 
-**6. Coordination Between Squads:**
-   - Squads operate independently within their zones. Lateral coordination at zone boundaries is the responsibility of adjacent squad leaders.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**7.** This OPORD is effective immediately upon distribution.
+**6.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/002d-movement-to-contact-detailed.md
+++ b/STX/002d-movement-to-contact-detailed.md
@@ -181,12 +181,7 @@ Priority of fires to 1st Squad. Mortar support is available through company on r
    - **LOA reached** — report on the platoon net.
    - **LACE Report** — on consolidation.
 
-**6. Coordination Between Squads:**
-   - Squads operate independently within their zones. Lateral coordination at zone boundaries is the responsibility of adjacent squad leaders.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**7.** This OPORD is effective immediately upon distribution.
+**6.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/003-raid-a-bunker-detailed.md
+++ b/STX/003-raid-a-bunker-detailed.md
@@ -171,12 +171,7 @@ Priority of fires to 3rd Squad. Mortar support is available through company on r
    - **LACE Report:** At least once during operation and upon consolidation.
    - **SALUTE Report:** Upon sighting enemy forces or indicators.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at their assigned objectives.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/003-raid-a-bunker.md
+++ b/STX/003-raid-a-bunker.md
@@ -150,9 +150,7 @@ Priority of fires to 3rd Squad. Mortar support is available through company on r
 
 **4. Reporting:** SP/LD, In Position at the ORP/objective, SALUTE on contact, LACE on consolidation. Submit any captured-materials report through the PL after consolidation.
 
-**5. Coordination Between Squads:** Squads operate independently at their objectives; adjacent squads continue their own mission on contact unless the PL directs otherwise.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/003b-raid-a-bunker-detailed.md
+++ b/STX/003b-raid-a-bunker-detailed.md
@@ -172,12 +172,7 @@ Priority of fires to 3rd Squad. Mortar support is available through company on r
    - **LACE Report:** At least once during operation and upon consolidation.
    - **Intelligence Report:** Upon SSE completion — report all communications equipment and materials captured.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at their assigned objectives.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/003c-raid-a-bunker-detailed.md
+++ b/STX/003c-raid-a-bunker-detailed.md
@@ -172,12 +172,7 @@ Priority of fires to 3rd Squad. Mortar support is available through company on r
    - **LACE Report:** At least once during operation and upon consolidation.
    - **Intelligence Report:** Upon SSE completion — report all weapons and materials found at each cache.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at their assigned objectives.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/003d-raid-a-bunker-detailed.md
+++ b/STX/003d-raid-a-bunker-detailed.md
@@ -172,12 +172,7 @@ Priority of fires to 3rd Squad. Mortar support is available through company on r
    - **LACE Report:** At least once during operation and upon consolidation.
    - **Intelligence Report:** Upon SSE completion — report all maps, notebooks, and materials found.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at their assigned objectives.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/005-area-zone-reconnaissance-detailed.md
+++ b/STX/005-area-zone-reconnaissance-detailed.md
@@ -173,12 +173,7 @@ Priority of fires to 1st Squad. Fires are limited to self-defense only. Avoid en
    - **Intelligence Report:** As intelligence is developed or at designated times.
    - **LACE Report:** Upon return to friendly lines.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at their assigned NAIs.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/005b-area-zone-reconnaissance-detailed.md
+++ b/STX/005b-area-zone-reconnaissance-detailed.md
@@ -173,12 +173,7 @@ Priority of fires to 1st Squad. Fires are limited to self-defense only. Mortar s
    - **Intelligence Report:** As intelligence is developed or at designated times.
    - **LACE Report:** Upon return to friendly lines.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at their assigned NAIs.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/005c-area-zone-reconnaissance-detailed.md
+++ b/STX/005c-area-zone-reconnaissance-detailed.md
@@ -173,12 +173,7 @@ Priority of fires to 1st Squad. Fires are limited to self-defense only. Mortar s
    - **Intelligence Report:** As intelligence is developed or at designated times.
    - **LACE Report:** Upon return to friendly lines.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at their assigned NAIs.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/005d-area-zone-reconnaissance-detailed.md
+++ b/STX/005d-area-zone-reconnaissance-detailed.md
@@ -173,12 +173,7 @@ Priority of fires to 1st Squad. Fires are limited to self-defense only. Mortar s
    - **Intelligence Report:** As intelligence is developed or at designated times.
    - **LACE Report:** Upon return to friendly lines.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at their assigned NAIs.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/014-deliberate-attack-detailed.md
+++ b/STX/014-deliberate-attack-detailed.md
@@ -174,12 +174,7 @@ Priority of fires to 2nd Squad. Mortar support is available through company on r
    - **Intelligence Report:** Upon completion of hasty SSE.
    - **LACE Report:** Upon seizure and consolidation on the objective.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at their assigned objectives.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/014b-deliberate-attack-detailed.md
+++ b/STX/014b-deliberate-attack-detailed.md
@@ -174,12 +174,7 @@ Priority of fires to 2nd Squad. Mortar support is available through company on r
    - **Intelligence Report:** Upon completion of hasty SSE.
    - **LACE Report:** Upon seizure and consolidation on the objective.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at assigned objectives.
-   - Squads report contact via SALUTE on the platoon net.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/014c-deliberate-attack-detailed.md
+++ b/STX/014c-deliberate-attack-detailed.md
@@ -174,12 +174,7 @@ Priority of fires to 2nd Squad. Mortar support is available through company on r
    - **Intelligence Report:** Upon completion of hasty SSE.
    - **LACE Report:** Upon seizure and consolidation.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at assigned objectives.
-   - Squads report contact via SALUTE on the platoon net.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/014d-deliberate-attack-detailed.md
+++ b/STX/014d-deliberate-attack-detailed.md
@@ -174,12 +174,7 @@ Priority of fires to 2nd Squad. Mortar support is available through company on r
    - **Intelligence Report:** Upon completion of hasty SSE — report all plans and materials recovered.
    - **LACE Report:** Upon seizure and consolidation.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at assigned objectives.
-   - Squads report contact via SALUTE on the platoon net.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/016-deliberate-attack-detailed.md
+++ b/STX/016-deliberate-attack-detailed.md
@@ -172,12 +172,7 @@ Priority of fires to 3rd Squad. Mortar support is available through company on r
    - **SALUTE Report:** Upon visual confirmation of enemy.
    - **LACE Report:** Upon seizure and consolidation on the objective.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at their assigned objectives.
-   - Squads report contact via SALUTE on the platoon net; adjacent squads monitor but continue their own missions unless directed otherwise by the PL.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/016b-deliberate-attack-detailed.md
+++ b/STX/016b-deliberate-attack-detailed.md
@@ -173,12 +173,7 @@ Priority of fires to 3rd Squad. Mortar support is available through company on r
    - **SALUTE Report:** Upon visual confirmation of enemy.
    - **LACE Report:** Upon seizure and consolidation on the objective.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at assigned objectives.
-   - Squads report contact via SALUTE on the platoon net.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/016c-deliberate-attack-detailed.md
+++ b/STX/016c-deliberate-attack-detailed.md
@@ -172,12 +172,7 @@ Priority of fires to 3rd Squad. Mortar support is available through company on r
    - **SALUTE Report:** Upon visual confirmation of enemy.
    - **LACE Report:** Upon seizure and consolidation on the objective.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at assigned objectives.
-   - Squads report contact via SALUTE on the platoon net.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 

--- a/STX/016d-deliberate-attack-detailed.md
+++ b/STX/016d-deliberate-attack-detailed.md
@@ -172,12 +172,7 @@ Priority of fires to 3rd Squad. Mortar support is available through company on r
    - **SALUTE Report:** Upon visual confirmation of enemy.
    - **LACE Report:** Upon seizure and consolidation on the objective.
 
-**5. Coordination Between Squads:**
-   - Squads operate independently at assigned objectives.
-   - Squads report contact via SALUTE on the platoon net.
-   - Squads requiring support request it through the PL.
-
-**6.** This OPORD is effective immediately upon distribution.
+**5.** This OPORD is effective immediately upon distribution.
 
 ---
 


### PR DESCRIPTION
The 5-paragraph OPORD's Coordinating Instructions covers ROE, CCIR,
EEFI, control measures, and reporting. A separate "Coordination Between
Squads" item that just restated "squads operate independently" was
non-doctrinal noise and duplicated what reporting and CCIR already say.
Stripped from all STX iterations and renumbered the trailing
effective-immediately item.